### PR TITLE
Ensure that it is `eslintLoc` in the calling context

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function monkeypatch() {
 
   var eslintLoc;
   try {
-    eslintLoc = require.resolve("eslint");
+    eslintLoc = Module._resolveFilename("eslint", module.parent);
   } catch (err) {
     throw new ReferenceError("couldn't resolve eslint");
   }


### PR DESCRIPTION
This PR will intended to fix the following two problems in using `gulp-eslint^0.5.0`.

#### Case1. If installed `eslint`, it is in deep than` babel-eslint`.

- node_moduels
  - babel-eslint
  - eslint
  - gulp-eslint
    - node_modules
      - eslint
      - ...

`gulp-eslint` use **node_modules/gulp-eslint/node_modules/eslint**, but `monkeypath` of `babel-lint` applies to **node_modules/eslint**. error such as assert from `Referencer.extend.ImportDeclaration` of `escope` occurs.

#### Case2. If the same level as the babel-eslint eslint is not installed.

- node_moduels
  - babel-eslint
  - gulp-eslint
    - node_modules
      - eslint
      - ...

`monkeypatch` will throw `new ReferenceError("couldn't resolve eslint")` ...

#### My idea.

use

```javascript
eslintLoc = Module._resolveFilename("eslint", module.parent);
```

instead of

```javascript
eslintLoc = require.resolve("eslint");
```

-----

They also considered the problem of related tools, but I think that it is formed by to work more reliably. How do you think? :)