### PR TITLE
Tests and some AST transform fixes

### DIFF
--- a/acorn-to-esprima.js
+++ b/acorn-to-esprima.js
@@ -7,9 +7,16 @@ exports.toToken = function (token) {
 
   if (type === tokTypes.name) {
     token.type = "Identifier";
-  } else if (type === tokTypes.semi || type === tokTypes.comma || type === tokTypes.parenL || type === tokTypes.parenR || type === tokTypes.braceL || type === tokTypes.braceR) {
+  } else if (type === tokTypes.semi || type === tokTypes.comma || type === tokTypes.parenL || type === tokTypes.parenR || type === tokTypes.braceL || type === tokTypes.braceR || type.isAssign) {
     token.type = "Punctuator";
-    token.value = type.type;
+    if (!token.value) {
+      token.value = type.type;
+    }
+  } else if (type.keyword) {
+    token.type = "Keyword";
+  } else if (type === tokTypes.num) {
+    token.type = "Numeric";
+    token.value = String(token.value);
   }
 
   return token;

--- a/acorn-to-esprima.js
+++ b/acorn-to-esprima.js
@@ -57,7 +57,12 @@ var astTransformVisitor = {
     }
 
     // classes
-    
+
+    if (t.isClassDeclaration(node) || t.isClassExpression(node)) {
+      node.name = node.id;
+      delete node.id;
+    }
+
     if (t.isReferencedIdentifier(node, parent, { name: "super" })) {
       return t.inherits(t.thisExpression(), node);
     }

--- a/package.json
+++ b/package.json
@@ -16,5 +16,12 @@
   "bugs": {
     "url": "https://github.com/babel/babel-eslint/issues"
   },
-  "homepage": "https://github.com/babel/babel-eslint"
+  "homepage": "https://github.com/babel/babel-eslint",
+  "devDependencies": {
+    "espree": "^1.10.0",
+    "mocha": "^2.1.0"
+  },
+  "scripts": {
+    "test": "mocha"
+  }
 }

--- a/test/babel-eslint.js
+++ b/test/babel-eslint.js
@@ -1,0 +1,71 @@
+var util = require("util");
+var espree = require("espree");
+var babelEslint = require("..");
+
+
+function assertSameAST(a, b, path) {
+  if (!path) {
+    path = [];
+  }
+
+  function error(text) {
+    throw new Error("At " + path.join(".") + ": " + text + ":\n" + util.inspect(a) + "\n" + util.inspect(b));
+  }
+
+  var typeA = a === null ? "null" : typeof a;
+  var typeB = b === null ? "null" : typeof b;
+  if (typeA !== typeB) {
+    error("have not the same type (" + typeA + " !== " + typeB + ")");
+  } else if (typeA === "object") {
+    var keysA = Object.keys(a);
+    var keysB = Object.keys(b);
+    keysA.sort();
+    keysB.sort();
+    while (true) {
+      var keyA = keysA.shift();
+
+      // Exception: ignore "end" and "start" outside "loc" properties
+      if ((keyA === "end" || keyA === "start") && path[path.length - 1] !== "loc") continue;
+      // Exception: ignore root "comments" property
+      if (keyA === "comments" && path.length === 0) continue;
+
+      var keyB = keysB.shift();
+
+      if (keyA === undefined && keyB === undefined) break;
+      if (keyA === undefined || keyA > keyB) error("first does not have key \"" + keyB + "\"");
+      if (keyB === undefined || keyA < keyB) error("second does not have key \"" + keyA + "\"");
+      path.push(keyA);
+      assertSameAST(a[keyA], b[keyB], path);
+      path.pop();
+    }
+  } else if (a !== b) {
+    error("are different (" + JSON.stringify(a) + " !== " + JSON.stringify(b) + ")");
+  }
+}
+
+function parseAndAssertSame(code) {
+    var esAST = espree.parse(code, {
+      ecmaFeatures: { classes: true },
+      tokens: true,
+      loc: true,
+      range: true
+    });
+    var acornAST = babelEslint.parse(code);
+    assertSameAST(acornAST, esAST);
+}
+
+describe("acorn-to-esprima", function () {
+
+  it("simple expression", function () {
+    parseAndAssertSame("a = 1");
+  });
+
+  it("class declaration", function () {
+    parseAndAssertSame("class Foo {}");
+  });
+
+  it("class expression", function () {
+    parseAndAssertSame("var a = class Foo {}");
+  });
+
+});


### PR DESCRIPTION
This project is great, but it lacks some unit tests. I wrote a starting point to this, as well as some fixes on tokens and `class` AST.

The `assertSameAST` function is pretty neat, it will help you find differences between expected `espree` AST and your transformed `acorn` AST, minus some expected exceptions.

The "class" fix will void the issues #21 and #8. It won't fix those, because class linting will fail with `'Foo' is not defined  no-undef`, the same error the current stable eslint prints. But at least, when eslint will fix this issue, `babel-eslint` will work too!