### PR TITLE
JSX AST fixes

### DIFF
--- a/acorn-to-esprima.js
+++ b/acorn-to-esprima.js
@@ -7,11 +7,19 @@ exports.toToken = function (token) {
 
   if (type === tokTypes.name) {
     token.type = "Identifier";
-  } else if (type === tokTypes.semi || type === tokTypes.comma || type === tokTypes.parenL || type === tokTypes.parenR || type === tokTypes.braceL || type === tokTypes.braceR || type.isAssign) {
+  } else if (type === tokTypes.semi || type === tokTypes.comma || type === tokTypes.parenL || type === tokTypes.parenR || type === tokTypes.braceL || type === tokTypes.braceR || type === tokTypes.slash || type === tokTypes.dot || type.isAssign) {
     token.type = "Punctuator";
     if (!token.value) {
       token.value = type.type;
     }
+  } else if (type === tokTypes.jsxTagStart) {
+    token.type = "Punctuator";
+    token.value = "<";
+  } else if (type === tokTypes.jsxTagEnd) {
+    token.type = "Punctuator";
+    token.value = ">";
+  } else if (type === tokTypes.jsxName) {
+    token.type = "JSXIdentifier";
   } else if (type.keyword) {
     token.type = "Keyword";
   } else if (type === tokTypes.num) {
@@ -70,22 +78,6 @@ var astTransformVisitor = {
     if (t.isClassProperty(node)) {
       // eslint doesn't like these
       this.remove();
-    }
-
-    // JSX
-
-    if (t.isJSXIdentifier(node)) {
-      if (node.name === "this" && t.isReferenced(node, parent)) {
-        return t.inherits(t.thisExpression(), node);
-      } else if (!t.isJSXAttribute(parent) && !isCompatTag(node.name)) {
-        node.type = "Identifier";
-      } else {
-        // just ignore this node as it'd be something like <div> or an attribute name
-      }
-    }
-
-    if (t.isJSXMemberExpression(node)) {
-      node.type = "MemberExpression";
     }
 
     // functions

--- a/index.js
+++ b/index.js
@@ -43,6 +43,17 @@ function monkeypatch() {
     opts.sourceType = "module";
     return analyze.call(this, ast, opts)
   };
+
+  var eslint = require(eslintLoc);
+  var getScope = eslint.linter.getScope;
+  eslint.linter.getScope = function () {
+    var scope = getScope.apply(this, arguments);
+    if (scope.type === "global" && !scope.__patchedWithModuleVariables) {
+      scope.__patchedWithModuleVariables = true;
+      scope.variables.push.apply(scope.variables, scope.childScopes[0].variables);
+    }
+    return scope;
+  };
 }
 
 exports.parse = function (code) {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://github.com/babel/babel-eslint",
   "devDependencies": {
+    "eslint": "^0.15.1",
     "espree": "^1.10.0",
     "mocha": "^2.1.0"
   },

--- a/test/babel-eslint.js
+++ b/test/babel-eslint.js
@@ -45,7 +45,10 @@ function assertSameAST(a, b, path) {
 
 function parseAndAssertSame(code) {
     var esAST = espree.parse(code, {
-      ecmaFeatures: { classes: true },
+      ecmaFeatures: {
+        classes: true,
+        jsx: true
+      },
       tokens: true,
       loc: true,
       range: true
@@ -66,6 +69,22 @@ describe("acorn-to-esprima", function () {
 
   it("class expression", function () {
     parseAndAssertSame("var a = class Foo {}");
+  });
+
+  it("jsx expression", function () {
+    parseAndAssertSame("<App />");
+  });
+
+  it("jsx expression with 'this' as identifier", function () {
+    parseAndAssertSame("<this />");
+  });
+
+  it("jsx expression with a dynamic attribute", function () {
+    parseAndAssertSame("<App foo={bar} />");
+  });
+
+  it("jsx expression with a member expression as identifier", function () {
+    parseAndAssertSame("<foo.bar />");
   });
 
 });

--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -78,6 +78,14 @@ describe("verify", function () {
     );
   });
 
+  it("Exported classes should be used (issue #8)", function () {
+    verifyAndAssertMessages(
+      "class Foo {} module.exports = Foo;",
+      { "no-unused-vars": 1 },
+      []
+    );
+  });
+
   it("super keyword in class (issue #10)", function () {
     verifyAndAssertMessages(
       "class Foo { constructor() { super() } }",
@@ -98,6 +106,14 @@ describe("verify", function () {
     verifyAndAssertMessages(
       "module.exports = <div className=\"foo\" />",
       { "no-undef": 1 },
+      []
+    );
+  });
+
+  it("Variables in JSX should be used (issues #15, #17, #21, #29)", function () {
+    verifyAndAssertMessages(
+      "import App from './App'; export default (<App />);",
+      { "no-unused-vars": 1, "no-undef": 1 },
       []
     );
   });

--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -1,0 +1,39 @@
+/*eslint-env mocha*/
+"use strict";
+var eslint = require("eslint");
+
+function verifyAndAssertMessages(code, rules, expectedMessages) {
+  var messages = eslint.linter.verify(
+    code,
+    {
+      parser: require.resolve(".."),
+      rules: rules,
+      env: {
+          node: true
+      }
+    }
+  );
+
+  if (messages.length !== expectedMessages.length) {
+    throw new Error("Expected " + expectedMessages.length + " message(s), got " + messages.length);
+  }
+
+  messages.forEach(function (message, i) {
+    var formatedMessage = message.line + ":" + message.column + " " + message.message + (message.ruleId ? " " + message.ruleId : "");
+    if (formatedMessage !== expectedMessages[i]) {
+      throw new Error("Message " + i + " does not match:\nExpected: " + expectedMessages[i] + "\nActual:   " + formatedMessage);
+    }
+  });
+}
+
+describe("verify", function () {
+
+  it("arrow function support (issue #1)", function () {
+    verifyAndAssertMessages(
+      "describe('stuff', () => {});",
+      {},
+      []
+    );
+  });
+
+});

--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -36,4 +36,94 @@ describe("verify", function () {
     );
   });
 
+  it("EOL validation (issue #2)", function () {
+    verifyAndAssertMessages(
+      "module.exports = \"something\";",
+      { "eol-last": 1, "semi": 1 },
+      [ "1:1 Newline required at end of file but not found. eol-last" ]
+    );
+  });
+
+  it("Readable error messages (issue #3)", function () {
+    verifyAndAssertMessages(
+      "{ , res }",
+      {},
+      [ "1:2 Unexpected token" ]
+    );
+  });
+
+  it("Unused vars in JSX (issue #5)", function () {
+    verifyAndAssertMessages(
+      "var App = require('./App');\n" +
+      "module.exports = <App />;",
+      { "no-unused-vars": 1 },
+      []
+    );
+  });
+
+  it("Modules support (issue #5)", function () {
+    verifyAndAssertMessages(
+      "import Foo from 'foo';\n" +
+      "export default Foo;",
+      { },
+      []
+    );
+  });
+
+  it("Rest parameters (issue #7)", function () {
+    verifyAndAssertMessages(
+      "function foo(...args) { return args; }",
+      { "no-undef": 1 },
+      []
+    );
+  });
+
+  it("super keyword in class (issue #10)", function () {
+    verifyAndAssertMessages(
+      "class Foo { constructor() { super() } }",
+      { "no-undef": 1 },
+      []
+    );
+  });
+
+  it("Rest parameter in destructuring assignment (issue #11)", function () {
+    verifyAndAssertMessages(
+      "const [a, ...rest] = ['1', '2', '3']; module.exports = rest;",
+      { "no-undef": 1 },
+      []
+    );
+  });
+
+  it("JSX attribute names marked as variables (issue #12)", function () {
+    verifyAndAssertMessages(
+      "module.exports = <div className=\"foo\" />",
+      { "no-undef": 1 },
+      []
+    );
+  });
+
+  it("Multiple destructured assignment with compound properties (issue #16)", function () {
+    verifyAndAssertMessages(
+      "module.exports = { ...a.a, ...a.b };",
+      { "no-dupe-keys": 1 },
+      []
+    );
+  });
+
+  it("Arrow function with non-block bodies (issue #20)", function () {
+    verifyAndAssertMessages(
+      "\"use strict\"; () => 1",
+      { "strict": 1 },
+      []
+    );
+  });
+
+  it("await keyword (issue #22)", function () {
+    verifyAndAssertMessages(
+      "async function foo() { await bar(); }",
+      { "no-unused-expressions": 1 },
+      []
+    );
+  });
+
 });


### PR DESCRIPTION
As `espree` now parses JSX, `babel-jslint` doesn't have to transform JSX node to normal ES nodes, they can stay the same, `eslint` will happily handle those.