### PR TITLE
Non regression tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://github.com/babel/babel-eslint",
   "devDependencies": {
+    "eslint": "^0.15.1",
     "espree": "^1.10.0",
     "mocha": "^2.1.0"
   },

--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -1,0 +1,39 @@
+/*eslint-env mocha*/
+"use strict";
+var eslint = require("eslint");
+
+function verifyAndAssertMessages(code, rules, expectedMessages) {
+  var messages = eslint.linter.verify(
+    code,
+    {
+      parser: require.resolve(".."),
+      rules: rules,
+      env: {
+          node: true
+      }
+    }
+  );
+
+  if (messages.length !== expectedMessages.length) {
+    throw new Error("Expected " + expectedMessages.length + " message(s), got " + messages.length);
+  }
+
+  messages.forEach(function (message, i) {
+    var formatedMessage = message.line + ":" + message.column + " " + message.message + (message.ruleId ? " " + message.ruleId : "");
+    if (formatedMessage !== expectedMessages[i]) {
+      throw new Error("Message " + i + " does not match:\nExpected: " + expectedMessages[i] + "\nActual:   " + formatedMessage);
+    }
+  });
+}
+
+describe("verify", function () {
+
+  it("arrow function support (issue #1)", function () {
+    verifyAndAssertMessages(
+      "describe('stuff', () => {});",
+      {},
+      []
+    );
+  });
+
+});

--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -36,4 +36,94 @@ describe("verify", function () {
     );
   });
 
+  it("EOL validation (issue #2)", function () {
+    verifyAndAssertMessages(
+      "module.exports = \"something\";",
+      { "eol-last": 1, "semi": 1 },
+      [ "1:1 Newline required at end of file but not found. eol-last" ]
+    );
+  });
+
+  it("Readable error messages (issue #3)", function () {
+    verifyAndAssertMessages(
+      "{ , res }",
+      {},
+      [ "1:2 Unexpected token" ]
+    );
+  });
+
+  it("Unused vars in JSX (issue #5)", function () {
+    verifyAndAssertMessages(
+      "var App = require('./App');\n" +
+      "module.exports = <App />;",
+      { "no-unused-vars": 1 },
+      []
+    );
+  });
+
+  it("Modules support (issue #5)", function () {
+    verifyAndAssertMessages(
+      "import Foo from 'foo';\n" +
+      "export default Foo;",
+      { },
+      []
+    );
+  });
+
+  it("Rest parameters (issue #7)", function () {
+    verifyAndAssertMessages(
+      "function foo(...args) { return args; }",
+      { "no-undef": 1 },
+      []
+    );
+  });
+
+  it("super keyword in class (issue #10)", function () {
+    verifyAndAssertMessages(
+      "class Foo { constructor() { super() } }",
+      { "no-undef": 1 },
+      []
+    );
+  });
+
+  it("Rest parameter in destructuring assignment (issue #11)", function () {
+    verifyAndAssertMessages(
+      "const [a, ...rest] = ['1', '2', '3']; module.exports = rest;",
+      { "no-undef": 1 },
+      []
+    );
+  });
+
+  it("JSX attribute names marked as variables (issue #12)", function () {
+    verifyAndAssertMessages(
+      "module.exports = <div className=\"foo\" />",
+      { "no-undef": 1 },
+      []
+    );
+  });
+
+  it("Multiple destructured assignment with compound properties (issue #16)", function () {
+    verifyAndAssertMessages(
+      "module.exports = { ...a.a, ...a.b };",
+      { "no-dupe-keys": 1 },
+      []
+    );
+  });
+
+  it("Arrow function with non-block bodies (issue #20)", function () {
+    verifyAndAssertMessages(
+      "\"use strict\"; () => 1",
+      { "strict": 1 },
+      []
+    );
+  });
+
+  it("await keyword (issue #22)", function () {
+    verifyAndAssertMessages(
+      "async function foo() { await bar(); }",
+      { "no-unused-expressions": 1 },
+      []
+    );
+  });
+
 });


### PR DESCRIPTION
It's me again, with more tests. `babel-eslint` is built on fast moving technologies, and tries to fix many edge cases users are reporting. To help people contribute, here is a simple non-regression test suit to make sure new changes won't breaks the previously fixed issues.

I read every closed issues and wrote a test when it was relevent. I checked if the test I wrote breaks when I removed the patch fixing the issue, just to be sure.