### PR TITLE
Added global flag to install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ columns is also retained so you can track down errors with ease.
 ### Install
 
 ```sh
-$ npm install eslint babel-eslint
+$ npm install -g eslint babel-eslint
 ```
 
 ### Setup


### PR DESCRIPTION
Just trying out to get this to run and it seems to me that the `-g` flag is needed, at least to get it working with the example mentioned below.

This just makes it easier to get started with copy&paste.