### PR TITLE
Attach comments to ast using estraverse

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var parse          = require("babel-core").parse;
 var path           = require("path");
 var t              = require("babel-core").types;
 
+var estraverse;
 var hasPatched = false;
 
 function createModule(filename) {
@@ -32,7 +33,7 @@ function monkeypatch() {
   var escopeMod = createModule(escopeLoc);
 
   // monkeypatch estraverse
-  var estraverse = escopeMod.require("estraverse");
+  estraverse = escopeMod.require("estraverse");
   assign(estraverse.VisitorKeys, t.VISITOR_KEYS);
 
   // monkeypatch escope
@@ -92,6 +93,7 @@ exports.parse = function (code) {
 
   // add comments
   ast.comments = comments;
+  estraverse.attachComments(ast, comments, tokens);
 
   // transform esprima and acorn divergent nodes
   acornToEsprima.toAST(ast);


### PR DESCRIPTION
fixes #60 
Greatly inspired by https://github.com/babel/babel/blob/master/src/babel/helpers/parse.js#L32

I haven't tested yet if this works for all comments, but I tried a few real quick and it seems to work. I'll try to get this running on the full ESLint test suite to see if it works on all comments related rules.