### PR TITLE
Support ES class properties

### DIFF
--- a/test/babel-eslint.js
+++ b/test/babel-eslint.js
@@ -26,7 +26,7 @@ function assertSameAST(a, b, path) {
 
       // Exception: ignore "end" and "start" outside "loc" properties
       if ((keyA === "end" || keyA === "start") && path[path.length - 1] !== "loc") continue;
-      
+
       // Exception: ignore root "comments" property
       if (keyA === "comments" && path.length === 0) continue;
 
@@ -66,6 +66,10 @@ describe("acorn-to-esprima", function () {
 
   it("class declaration", function () {
     parseAndAssertSame("class Foo {}");
+  });
+
+  it("class properties", function () {
+    parseAndAssertSame("class Foo { a = () => {}; }");
   });
 
   it("class expression", function () {


### PR DESCRIPTION
Trying to reproduce the following error

```js
class Foo {
  test = () => {
    console.log('test');
  };
}
```

```
TypeError: Cannot read property 'type' of undefined
    at hasTypeOfOperator (.\node_modules\eslint\lib\rules\no-undef.js:53:18)
    at .\node_modules\eslint\lib\rules\no-undef.js:75:21
    at Array.forEach (native)
    at EventEmitter.Program:exit (.\node_modules\eslint\lib\rules\no-undef.js:71:33)
    at EventEmitter.emit (events.js:129:20)
    at Controller.controller.traverse.leave (.\node_modules\eslint\lib\eslint.js:734:25)
    at Controller.__execute (.\node_modules\eslint\node_modules\estraverse\estraverse.js:393:31)
    at Controller.traverse (.\node_modules\eslint\node_modules\estraverse\estraverse.js:481:28)
    at EventEmitter.module.exports.api.verify (.\node_modules\eslint\lib\eslint.js:719:24)
    at processFile (.\node_modules\eslint\lib\cli-engine.js:195:27)
```

Just a unit test for now. Ref #71