### PR TITLE
also patch estraverse-fb - fixes #73

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,10 @@ function monkeypatch() {
   estraverse = escopeMod.require("estraverse");
   assign(estraverse.VisitorKeys, t.VISITOR_KEYS);
 
+  // monkeypatch estraverse-fb
+  var estraverseFb = eslintMod.require("estraverse-fb");
+  assign(estraverseFb.VisitorKeys, t.VISITOR_KEYS);
+
   // monkeypatch escope
   var escope  = require(escopeLoc);
   var analyze = escope.analyze;


### PR DESCRIPTION
Was trying to get jscs working and got a similar error.

Not sure if this is right but eslint is also using estraverse at https://github.com/eslint/eslint/blob/master/lib/eslint.js#L11. Patching the keys for that reference of estraverse seems to fix the `Unknown node type ExportDefaultSpecifier` error.