### PR TITLE
Fix flow import type

### DIFF
--- a/acorn-to-esprima.js
+++ b/acorn-to-esprima.js
@@ -69,6 +69,9 @@ var astTransformVisitor = {
     // modules
 
     if (t.isImportDeclaration(node)) {
+      if (node.isType) {
+        return this.remove();
+      }
       delete node.isType;
     }
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/babel/babel-eslint",
   "devDependencies": {
-    "eslint": "^0.18.0",
+    "eslint": "^0.21.0",
     "espree": "^2.0.0",
     "mocha": "^2.1.0"
   }

--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -139,4 +139,12 @@ describe("verify", function () {
       []
     );
   });
+
+  it("flow import types", function() {
+    verifyAndAssertMessages(
+      "import type Foo from 'foo';",
+      { "no-unused-vars": 1 },
+      []
+    );
+  });
 });


### PR DESCRIPTION
```
import type Foo from 'foo';
```

with eslint 0.21.0, the code above will cause error: 

```
error  Foo is defined but never used  no-unused-vars
```