### PR TITLE
change more tokentypes to be punctuator - fixes #59

### DIFF
--- a/acorn-to-esprima.js
+++ b/acorn-to-esprima.js
@@ -13,7 +13,16 @@ exports.toToken = function (token) {
              type === tt.slash || type === tt.dot ||
              type === tt.bracketL || type === tt.bracketR ||
              type === tt.ellipsis || type === tt.arrow ||
-             type === tt.star ||
+             type === tt.star || type === tt.incDec ||
+             type === tt.colon || type === tt.question ||
+             type === tt.template || type === tt.backQuote ||
+             type === tt.dollarBraceL || type === tt.at ||
+             type === tt.logicalOR || type === tt.logicalAND ||
+             type === tt.bitwiseOR || type === tt.bitwiseXOR ||
+             type === tt.bitwiseAND || type === tt.equality ||
+             type === tt.relational || type === tt.bitShift ||
+             type === tt.plusMin || type === tt.modulo ||
+             type === tt.exponent || type === tt.prefix ||
              type.isAssign) {
     token.type = "Punctuator";
     if (!token.value) token.value = type.label;


### PR DESCRIPTION
#59.

Came across as similar issue in jscs as well. Some of the rules are checking something like `op.type === "Punctuator"` but some of the types are still `TokenType` rather than a string.

I basically just added everything in https://github.com/babel/babel/blob/master/src/acorn/src/tokentype.js#L48-L96 that wasn't already there.

I'm not sure we want all of these though?