### PR TITLE
add tokenTypes: Null, Boolean, RegularExpression

### DIFF
--- a/acorn-to-esprima.js
+++ b/acorn-to-esprima.js
@@ -34,6 +34,10 @@ exports.toToken = function (token) {
     token.value = ">";
   } else if (type === tt.jsxName) {
     token.type = "JSXIdentifier";
+  } else if (type.keyword === "null") {
+    token.type = "Null";
+  } else if (type.keyword === "false" || token.keyword === "true") {
+    token.type = "Boolean";
   } else if (type.keyword) {
     token.type = "Keyword";
   } else if (type === tt.num) {
@@ -42,6 +46,8 @@ exports.toToken = function (token) {
   } else if (type === tt.string) {
     token.type = "String";
     token.value = JSON.stringify(token.value);
+  } else if (type === tt.regexp) {
+    token.type = "RegularExpression";
   }
 
   return token;


### PR DESCRIPTION
Looking at the token types
in espree: https://github.com/eslint/espree/blob/master/lib/token-info.js#L57-L68
in esprima: https://github.com/jquery/esprima/blob/master/esprima.js#L85-L94.

Only additions are `JSXText` and `JSXIdentifier` in espree.

This adds `Null`, `Boolean`, `RegularExpression`.

Not sure about the `Template` token type since it seems that we would have to combine tokens? https://github.com/babel/babel-eslint/issues/31#issuecomment-100912106

