### PR TITLE
support template strings - Fixes #31

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ function monkeypatch() {
   };
 }
 
-exports.attachComments = function(ast, comments, tokens) {
+exports.attachComments = function (ast, comments, tokens) {
   estraverse.attachComments(ast, comments, tokens);
 
   if (comments.length) {
@@ -82,7 +82,7 @@ exports.attachComments = function(ast, comments, tokens) {
         node.leadingComments = [];
         var firstTokenStart = token.range[0];
         var len = comments.length;
-        for(var i = 0; i < len && comments[i].start < firstTokenStart; i++ ) {
+        for (var i = 0; i < len && comments[i].start < firstTokenStart; i++) {
           node.leadingComments.push(comments[i]);
         }
       }
@@ -138,7 +138,7 @@ exports.parse = function (code) {
   tokens.pop();
 
   // convert tokens
-  ast.tokens = tokens.map(acornToEsprima.toToken);
+  ast.tokens = acornToEsprima.toTokens(tokens);
 
   // add comments
   ast.comments = comments;

--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -139,4 +139,14 @@ describe("verify", function () {
       []
     );
   });
+
+  it("template strings #31", function () {
+    verifyAndAssertMessages(
+      "console.log(`${a}, b`);",
+      { "comma-spacing": 1 },
+      []
+    );
+  });
+
+
 });


### PR DESCRIPTION
So I tried to understand your comment about the acorn parser here: https://github.com/babel/babel-eslint/pull/93#issuecomment-101463267 and ended up with this?

Got the tests to pass at least!

Not sure what I'm doing haha... so I'm wondering what your thoughts are? 

A fix I didn't do yet is: https://github.com/marijnh/acorn/blob/master/test/tests-harmony.js#L808
where `esprima: "\\n\\r\\b\\v\\t\\f\\\n\\\r\n"` and `acorn: "\n\r\b\u000b\t\f"`

Also looked at
https://github.com/jquery/esprima/pull/1121/files
https://github.com/jquery/esprima/blob/240e0bede7c78ab79927004cef7b422c96ed072e/esprima.js#L1111
