### PR TITLE
add JSXText type, more tests

### DIFF
--- a/acorn-to-esprima.js
+++ b/acorn-to-esprima.js
@@ -34,6 +34,8 @@ exports.toToken = function (token) {
     token.value = ">";
   } else if (type === tt.jsxName) {
     token.type = "JSXIdentifier";
+  } else if (type === tt.jsxText) {
+    token.type = "JSXText";
   } else if (type.keyword === "null") {
     token.type = "Null";
   } else if (type.keyword === "false" || type.keyword === "true") {

--- a/test/babel-eslint.js
+++ b/test/babel-eslint.js
@@ -154,6 +154,22 @@ describe("acorn-to-esprima", function () {
     parseAndAssertSame("<foo.bar />");
   });
 
+  it("jsx expression with spread", function () {
+    parseAndAssertSame("var myDivElement = <div {...this.props} />;");
+  });
+
+  it("empty jsx text", function () {
+    parseAndAssertSame("<a></a>");
+  });
+
+  it("jsx text with content", function () {
+    parseAndAssertSame("<a>Hello, world!</a>");
+  });
+
+  it("nested jsx", function () {
+    parseAndAssertSame("<div>\n<h1>Wat</h1>\n</div>");
+  });
+
   it("default import", function () {
     parseAndAssertSame('import foo from "foo";');
   });


### PR DESCRIPTION
Fixes an eslint test relating to jsx and comma spacing - `<a>Hello, world!</a>`

From https://github.com/eslint/espree/blob/master/lib/token-info.js#L67-L68

> TokenName[Token.JSXText] = "JSXText";

https://github.com/RReverser/acorn-jsx/blob/54ad51d57cac46ed5327095e7e987ff4decee431/inject.js#L11-L14

```
  tt.jsxName = new acorn.TokenType('jsxName');
  tt.jsxText = new acorn.TokenType('jsxText', {beforeExpr: true});
  tt.jsxTagStart = new acorn.TokenType('jsxTagStart');
  tt.jsxTagEnd = new acorn.TokenType('jsxTagEnd');
```