### PR TITLE
patch escope to visit decorators - fixes #72

### DIFF
--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -55,7 +55,7 @@ describe("verify", function () {
     verifyAndAssertMessages(
       "import Foo from 'foo';\n" +
       "export default Foo;",
-      { },
+      {},
       []
     );
   });
@@ -162,5 +162,97 @@ describe("verify", function () {
       { "comma-spacing": 1 },
       []
     );
+  });
+
+  describe("decorators #72", function () {
+    it("class declaration", function () {
+      verifyAndAssertMessages(
+        [
+          "import classDeclaration from 'decorator';",
+          "import decoratorParameter from 'decorator';",
+          "@classDeclaration(decoratorParameter)",
+          "@classDeclaration",
+          "class TextareaAutosize {}"
+        ].join("\n"),
+        { "no-unused-vars": 1 },
+        []
+      );
+    });
+
+    it("method definition", function () {
+      verifyAndAssertMessages(
+        [
+          "import classMethodDeclarationA from 'decorator';",
+          "import decoratorParameter from 'decorator';",
+          "class TextareaAutosize {",
+            "@classMethodDeclarationA(decoratorParameter)",
+            "@classMethodDeclarationA",
+            "methodDeclaration(e) {",
+              "e();",
+            "}",
+          "}"
+        ].join("\n"),
+        { "no-unused-vars": 1 },
+        []
+      );
+    });
+
+    it("method definition get/set", function () {
+      verifyAndAssertMessages(
+        [
+          "import classMethodDeclarationA from 'decorator';",
+          "import decoratorParameter from 'decorator';",
+          "class TextareaAutosize {",
+            "@classMethodDeclarationA(decoratorParameter)",
+            "@classMethodDeclarationA",
+            "get bar() { }",
+            "@classMethodDeclarationA(decoratorParameter)",
+            "@classMethodDeclarationA",
+            "set bar() { }",
+          "}"
+        ].join("\n"),
+        { "no-unused-vars": 1 },
+        []
+      );
+    });
+
+    it("object property", function () {
+      verifyAndAssertMessages(
+        [
+          "import classMethodDeclarationA from 'decorator';",
+          "import decoratorParameter from 'decorator';",
+          "var obj = {",
+            "@classMethodDeclarationA(decoratorParameter)",
+            "@classMethodDeclarationA",
+            "methodDeclaration(e) {",
+              "e();",
+            "}",
+          "};",
+          "obj;"
+        ].join("\n"),
+        { "no-unused-vars": 1 },
+        []
+      );
+    });
+
+    it("object property get/set", function () {
+      verifyAndAssertMessages(
+        [
+          "import classMethodDeclarationA from 'decorator';",
+          "import decoratorParameter from 'decorator';",
+          "var obj = {",
+            "@classMethodDeclarationA(decoratorParameter)",
+            "@classMethodDeclarationA",
+            "get bar() { },",
+            "@classMethodDeclarationA(decoratorParameter)",
+            "@classMethodDeclarationA",
+            "set bar() { }",
+          "};",
+          "obj;"
+        ].join("\n"),
+        { "no-unused-vars": 1 },
+        []
+      );
+    });
   });
 });


### PR DESCRIPTION
Adding more to what @matteosuppo did in #75 which should fix #72?

Referenced: https://github.com/wycats/javascript-decorators
Simplified the code to patch escope.
Patch referencer: https://github.com/estools/escope/blob/master/src/referencer.js
- visitClass method: https://github.com/estools/escope/blob/master/src/referencer.js#L353
- visitProperty method: https://github.com/estools/escope/blob/master/src/referencer.js#L384

Add tests for all including params, get/set.

~~So the tests added in `non-regression.js` still pass without the changes in `index.js`. Might be something dumb.~~ Fixed.