### PR TITLE
support comprehensions (no-undef) - fixes #9

### DIFF
--- a/index.js
+++ b/index.js
@@ -276,6 +276,9 @@ function monkeypatch() {
         }
       }
     }
+    if (node.right) {
+      this.visit(node.right);
+    }
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -173,10 +173,6 @@ function monkeypatch() {
   var visitClass = referencer.prototype.visitClass;
   referencer.prototype.visitClass = function(node) {
     visitDecorators.call(this, node);
-    // visit class
-    if (node.id) {
-      this.visit(node.id);
-    }
     // visit flow type: ClassImplements
     if (node.implements) {
       for (var i = 0; i < node.implements.length; i++) {

--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -255,9 +255,8 @@ describe("verify", function () {
 
     it("ClassImplements", function () {
       verifyAndAssertMessages([
-          "import type Foo from 'foo';",
           "import type Bar from 'foo';",
-          "class Foo implements Bar {}"
+          "export default class Foo implements Bar {}"
         ].join("\n"),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
@@ -459,7 +458,7 @@ describe("verify", function () {
         [
           "import type Foo from 'foo';",
           "import type Foo2 from 'foo';",
-          "class Bar {set fooProp(value:Foo):Foo2{ value; }}"
+          "export default class Bar {set fooProp(value:Foo):Foo2{ value; }}"
         ].join("\n"),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
@@ -469,8 +468,8 @@ describe("verify", function () {
     it("15", function () {
       verifyAndAssertMessages(
         [
-          "import type Foo from 'foo';",
-          "class Foo {get fooProp():Foo{}}"
+          "import type Foo2 from 'foo';",
+          "export default class Foo {get fooProp(): Foo2{}}"
         ].join("\n"),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
@@ -581,7 +580,7 @@ describe("verify", function () {
           "import type Foo from 'foo';",
           "import type Foo2 from 'foo';",
           "import Baz from 'foo';",
-          "class Bar<Foo> extends Baz<Foo2> { };"
+          "export default class Bar<Foo> extends Baz<Foo2> { };"
         ].join("\n"),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
@@ -594,7 +593,7 @@ describe("verify", function () {
           "import type Foo from 'foo';",
           "import type Foo2 from 'foo';",
           "import type Foo3 from 'foo';",
-          "class Bar<Foo> { bar<Foo2>():Foo3 { return 42; }}"
+          "export default class Bar<Foo> { bar<Foo2>():Foo3 { return 42; }}"
         ].join("\n"),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
@@ -606,7 +605,7 @@ describe("verify", function () {
         [
           "import type Foo from 'foo';",
           "import type Foo2 from 'foo';",
-          "class Bar { static prop1:Foo; prop2:Foo2; }"
+          "export default class Bar { static prop1:Foo; prop2:Foo2; }"
         ].join("\n"),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
@@ -881,6 +880,19 @@ describe("verify", function () {
     verifyAndAssertMessages(
       "class Lol {} module.exports = Lol;",
       { "no-unused-vars": 1 },
+      []
+    );
+  });
+
+  it("class definition: gaearon/redux#24", function () {
+    verifyAndAssertMessages([
+        "export default function root(stores) {",
+          "return DecoratedComponent => class ReduxRootDecorator {",
+            "a() { DecoratedComponent; }",
+          "};",
+        "}",
+      ].join("\n"),
+      { "no-undef": 1, "no-unused-vars": 1 },
       []
     );
   });

--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -916,32 +916,43 @@ describe("verify", function () {
 
   describe("comprehensions", function () {
     it("array #9", function () {
-      verifyAndAssertMessages(
-        "let b = [for (e of a) String(e)];",
+      verifyAndAssertMessages([
+          "let arr = [1, 2, 3];",
+          "let b = [for (e of arr) String(e)];"
+        ].join("\n"),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("array, if statement, multiple blocks", function () {
-      verifyAndAssertMessages(
-        "[for (x of array) for (y of array2) if (x === true && y === true) x + y];",
+      verifyAndAssertMessages([
+          "let arr = [1, 2, 3];",
+          "let arr2 = [1, 2, 3];",
+          "[for (x of arr) for (y of arr2) if (x === true && y === true) x + y];"
+        ].join("\n"),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("expression, if statement, multiple blocks", function () {
-      verifyAndAssertMessages(
-        "(for (x of array) for (y of array2) if (x === true && y === true) x + y)",
+      verifyAndAssertMessages([
+          "let arr = [1, 2, 3];",
+          "let arr2 = [1, 2, 3];",
+          "(for (x of arr) for (y of arr2) if (x === true && y === true) x + y)"
+        ].join("\n"),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("ArrayPattern", function () {
-      verifyAndAssertMessages(
-        "[for ([,x] of array) for ({[start.x]: x, [start.y]: y} of array2) x]",
+      verifyAndAssertMessages([
+          "let arr = [1, 2, 3];",
+          "let arr2 = [1, 2, 3];",
+          "[for ([,x] of arr) for ({[start.x]: x, [start.y]: y} of arr2) x]"
+        ].join("\n"),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );

--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -914,6 +914,40 @@ describe("verify", function () {
     );
   });
 
+  describe("comprehensions", function () {
+    it("array #9", function () {
+      verifyAndAssertMessages(
+        "let b = [for (e of a) String(e)];",
+        { "no-undef": 1 },
+        []
+      );
+    });
+
+    it("array, if statement, multiple blocks", function () {
+      verifyAndAssertMessages(
+        "[for (x of array) for (y of array2) if (x === true) x];",
+        { "no-undef": 1 },
+        []
+      );
+    });
+
+    it("expression, if statement, multiple blocks", function () {
+      verifyAndAssertMessages(
+        "(for (x of array) for (y of array2) if (x === true) x)",
+        { "no-undef": 1 },
+        []
+      );
+    });
+
+    it("ArrayPattern", function () {
+      verifyAndAssertMessages(
+        "[for ([,x] of array) for ({[start.x]: x, [start.y]: y} of array2) x]",
+        { "no-undef": 1 },
+        []
+      );
+    });
+  });
+
   describe("decorators #72", function () {
     it("class declaration", function () {
       verifyAndAssertMessages(

--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -918,23 +918,23 @@ describe("verify", function () {
     it("array #9", function () {
       verifyAndAssertMessages(
         "let b = [for (e of a) String(e)];",
-        { "no-undef": 1 },
+        { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("array, if statement, multiple blocks", function () {
       verifyAndAssertMessages(
-        "[for (x of array) for (y of array2) if (x === true) x];",
-        { "no-undef": 1 },
+        "[for (x of array) for (y of array2) if (x === true && y === true) x + y];",
+        { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("expression, if statement, multiple blocks", function () {
       verifyAndAssertMessages(
-        "(for (x of array) for (y of array2) if (x === true) x)",
-        { "no-undef": 1 },
+        "(for (x of array) for (y of array2) if (x === true && y === true) x + y)",
+        { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
@@ -942,7 +942,7 @@ describe("verify", function () {
     it("ArrayPattern", function () {
       verifyAndAssertMessages(
         "[for ([,x] of array) for ({[start.x]: x, [start.y]: y} of array2) x]",
-        { "no-undef": 1 },
+        { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });


### PR DESCRIPTION
Fixes #9 
Only checking for `Identifier`: `(e of a)` and `ArrayPattern`: `for ([,x] of array)`.