### PR TITLE
update to eslint@0.22.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/babel/babel-eslint",
   "devDependencies": {
-    "eslint": "^0.21.2",
+    "eslint": "^0.22.1",
     "espree": "^2.0.0",
     "mocha": "^2.1.0"
   }

--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -185,7 +185,7 @@ describe("verify", function () {
           "import decoratorParameter from 'decorator';",
           "@classDeclaration(decoratorParameter)",
           "@classDeclaration",
-          "class TextareaAutosize {}"
+          "export class TextareaAutosize {}"
         ].join("\n"),
         { "no-unused-vars": 1 },
         []
@@ -197,7 +197,7 @@ describe("verify", function () {
         [
           "import classMethodDeclarationA from 'decorator';",
           "import decoratorParameter from 'decorator';",
-          "class TextareaAutosize {",
+          "export class TextareaAutosize {",
             "@classMethodDeclarationA(decoratorParameter)",
             "@classMethodDeclarationA",
             "methodDeclaration(e) {",
@@ -215,7 +215,7 @@ describe("verify", function () {
         [
           "import classMethodDeclarationA from 'decorator';",
           "import decoratorParameter from 'decorator';",
-          "class TextareaAutosize {",
+          "export class TextareaAutosize {",
             "@classMethodDeclarationA(decoratorParameter)",
             "@classMethodDeclarationA",
             "get bar() { }",


### PR DESCRIPTION
Had to change the tests to fix the `no-unused-vars` error for classes since it looks like escope updated.