### PR TITLE
add flow exceptions for polymorphic types - Ref #109

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,6 +163,10 @@ function monkeypatch() {
     if (node.typeAnnotation) {
       visitTypeAnnotation.call(this, node.typeAnnotation);
     } else if (node.type === "Identifier") {
+      // exception for polymorphic types: <T>, <A>, etc
+      if (node.name.length === 1 && node.name === node.name.toUpperCase()) {
+        return;
+      }
       this.visit(node);
     } else {
       visitTypeAnnotation.call(this, node);

--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -297,6 +297,26 @@ describe("verify", function () {
       );
     });
 
+    it("polymorphpic types #109", function () {
+      verifyAndAssertMessages([
+          "export default function groupByEveryN<T>(array: Array<T>, n: number): Array<Array<?T>> {}"
+        ].join("\n"),
+        { "no-unused-vars": 1, "no-undef": 1 },
+        []
+      );
+    });
+
+    it("types definition from import", function () {
+      verifyAndAssertMessages([
+          "import type Promise from 'bluebird';",
+          "type Operation = () => Promise;",
+          "x: Operation;"
+        ].join("\n"),
+        { "no-unused-vars": 1, "no-undef": 1 },
+        []
+      );
+    });
+
     it("1", function () {
       verifyAndAssertMessages(
         [


### PR DESCRIPTION
For 

https://github.com/babel/babel-eslint/pull/109#issuecomment-107781203

```js
export function foo<X>(x: X): X {
  return x;
}
```
`  3:20  error  "X" is not defined  no-undef`

~~Also for `mixed` by not visiting those 2 cases.~~ Fixed in babel/babel#1669