### PR TITLE
only visit properties in object destructuring when there is a SpreadP…

### DIFF
--- a/acorn-to-esprima.js
+++ b/acorn-to-esprima.js
@@ -172,7 +172,7 @@ var astTransformVisitor = {
   noScope: true,
   exit: function (node) { /* parent */
     if (this.isSpreadProperty()) {
-      node.type = "Property";
+      node.type = "SpreadProperty";
       node.kind = "init";
       node.computed = true;
       node.key = node.value = node.argument;

--- a/index.js
+++ b/index.js
@@ -264,8 +264,15 @@ function monkeypatch() {
           checkIdentifierOrVisit.call(this, typeAnnotation);
         }
         if (id.type === "ObjectPattern") {
-          for (var j = 0; j < id.properties.length; j++) {
-            this.visit(id.properties[j]);
+          // check if object destructuring has a spread
+          var hasSpread = id.properties.filter(function(p) {
+            return p.type === "SpreadProperty"
+          });
+          // visit properties if so
+          if (hasSpread.length > 0) {
+            for (var j = 0; j < id.properties.length; j++) {
+              this.visit(id.properties[j]);
+            }
           }
         }
       }

--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -1171,4 +1171,12 @@ describe("verify", function () {
       []
     );
   });
+
+  it("detects no-unused-vars with object destructuring #142", function () {
+    verifyAndAssertMessages(
+      "const {Bacona} = require('baconjs')",
+      { "no-undef": 1, "no-unused-vars": 1 },
+      [ "1:7 Bacona is defined but never used no-unused-vars" ]
+    );
+  });
 });


### PR DESCRIPTION
…roperty - fixes #142 

WIP

@sebmck How can I check if one of the properties is a spread property (since we changed the `node.type`). I just changed it to SpreadProperty but I'm assuming that may break something?

Since we want to only visit when a SpreadProperty is used (and I guess more specifically visit only properties left of it)

Ref #95 
@cassus tell me if this fixes your issue