### PR TITLE
use SpreadProperty type, revert other transforms

### DIFF
--- a/acorn-to-esprima.js
+++ b/acorn-to-esprima.js
@@ -183,11 +183,8 @@ var astTransformVisitor = {
   },
   exit: function (node) { /* parent */
     if (this.isSpreadProperty()) {
-      node.type = "Property";
-      node.kind = "init";
-      node.computed = true;
+      node.type = "SpreadProperty";
       node.key = node.value = node.argument;
-      delete node.argument;
     }
 
     // flow: prevent "no-undef"


### PR DESCRIPTION
Ref original issue https://github.com/babel/babel-eslint/issues/7

`node.key = node.value = node.argument;` is needed (failed test)

Fixes xjamundx/eslint-plugin-standard#3

Looks like no issue with babel-eslint, react, react-bootstrap, express-graphql, or graphql-js tests.