### PR TITLE
remove async func transform

### DIFF
--- a/acorn-to-esprima.js
+++ b/acorn-to-esprima.js
@@ -239,11 +239,6 @@ var astTransformVisitor = {
 
     // functions
 
-    if (this.isFunction()) {
-      if (node.async) node.generator = true;
-      delete node.async;
-    }
-
     if (this.isAwaitExpression()) {
       node.type = "YieldExpression";
       node.delegate = node.all;


### PR DESCRIPTION
Ref original issue: https://github.com/babel/babel-eslint/issues/22
test added in https://github.com/babel/babel-eslint/commit/a35161d3aac2b07e21e0b8f7f517ac92671a58bc#diff-49183fcdab9e2cd1f1f6c0226baf60d1R121

Need `node.async` to be there

Ref babel/eslint-plugin-babel#8

Looks like no issue with babel-eslint, react, react-bootstrap, express-graphql, or graphql-js tests.