### PR TITLE
async func and space-before-function-paren

### DIFF
--- a/acorn-to-esprima.js
+++ b/acorn-to-esprima.js
@@ -235,6 +235,10 @@ var astTransformVisitor = {
 
     // functions
 
+    if (this.isFunction()) {
+      if (node.async) node.generator = true;
+    }
+
     if (this.isAwaitExpression()) {
       node.type = "YieldExpression";
       node.delegate = node.all;

--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -1302,4 +1302,11 @@ describe("verify", function () {
       [ ]
     )
   });
+
+  it("async function with space-before-function-paren #168", function () {
+    verifyAndAssertMessages("it('handles updates', async function() {});",
+      { "space-before-function-paren": [1, "never"] },
+      [ ]
+    )
+  });
 });


### PR DESCRIPTION
For #168.

WIP: Probably not the fix we want but added the test.

Actually based on https://github.com/eslint/eslint/blob/master/lib/rules/space-before-function-paren.js#L71-L73 maybe it is. Other solution would be to remove the transform and that the rule to eslint-plugin-babel with a check for `node.async`. Or we do the private properties thing again like `._babelType`...