### PR TITLE
Avoid errors with eslint 1.10.x when excluding destructured properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -295,18 +295,15 @@ function monkeypatch() {
         if (typeAnnotation) {
           checkIdentifierOrVisit.call(this, typeAnnotation);
         }
-        if (!patternVisitor) {
-          // Old method. Once escope in eslint is updated, this code is not necessary.
-          if (id.type === "ObjectPattern") {
-            // check if object destructuring has a spread
-            var hasSpread = id.properties.filter(function(p) {
-              return p._babelType === "SpreadProperty";
-            });
-            // visit properties if so
-            if (hasSpread.length > 0) {
-              for (var j = 0; j < id.properties.length; j++) {
-                this.visit(id.properties[j]);
-              }
+        if (id.type === "ObjectPattern") {
+          // check if object destructuring has a spread
+          var hasSpread = id.properties.filter(function(p) {
+            return p._babelType === "SpreadProperty";
+          });
+          // visit properties if so
+          if (hasSpread.length > 0) {
+            for (var j = 0; j < id.properties.length; j++) {
+              this.visit(id.properties[j]);
             }
           }
         }


### PR DESCRIPTION
Despite @Constellation's improvements from #209 with the pattern visitor, it doesn't actually iterate over the Property node siblings of the SpreadProperty. Thus, the "ignore properties left of spread" fix in #95 regressed.

Restoring the "old" path of looping over all properties of an ObjectPattern that contains a SpreadProperty avoids the regression. It seems inelegant, but I don't have enough insight into the referencer to propose an alternative.