### PR TITLE
Update acorn-to-esprima and bump beta version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-eslint",
-  "version": "5.0.0-beta4",
+  "version": "5.0.0-beta5",
   "description": "",
   "main": "index.js",
   "repository": {
@@ -8,7 +8,7 @@
     "url": "https://github.com/babel/babel-eslint.git"
   },
   "dependencies": {
-    "acorn-to-esprima": "^2.0.1",
+    "acorn-to-esprima": "^2.0.2",
     "babel-traverse": "^6.0.20",
     "babel-types": "^6.0.19",
     "babylon": "^6.0.18",


### PR DESCRIPTION
force acorn-to-esprima patch by bumping published beta version 