### PR TITLE
Update README.md install docs for eslint v1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ It just needs to export a `parse` method that takes in a string of code and outp
 ### Install
 
 ```sh
-$ npm install eslint babel-eslint --save-dev
+$ npm install eslint@1.x babel-eslint --save-dev
 ```
 
 ### Setup


### PR DESCRIPTION
I gather from https://github.com/babel/babel-eslint/issues/254 that `babel-eslint` is not currently compatible with eslint@2.x, in which case the docs should be updated to lock in eslint@1.x