### PR TITLE
remove monkey-patching of patternVisitor as unused

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,22 +92,6 @@ function monkeypatch() {
     referencer = referencer.default;
   }
 
-  // monkeypatch escope/pattern-visitor
-  var patternVisitorLoc;
-  var patternVisitorMod;
-  var patternVisitor;
-  try {
-    patternVisitorLoc = Module._resolveFilename("./pattern-visitor", escopeMod);
-    patternVisitorMod = createModule(patternVisitorLoc);
-    patternVisitor = require(patternVisitorLoc);
-    if (patternVisitor.__esModule) {
-      patternVisitor = patternVisitor.default;
-    }
-  } catch (err) {
-    // When eslint uses old escope, we cannot find pattern visitor.
-    // Fallback to the old way.
-  }
-
   // reference Definition
   var definitionLoc;
   try {
@@ -303,12 +287,6 @@ function monkeypatch() {
       this.close(node);
     }
   };
-
-  if (patternVisitor) {
-    patternVisitor.prototype.SpreadProperty = function (node) {
-      this.visit(node.argument);
-    };
-  }
 
   // visit flow type in VariableDeclaration
   var variableDeclaration = referencer.prototype.VariableDeclaration;


### PR DESCRIPTION
SpreadProperty will never be visited as it is now called ExperimentalSpreadProperty
We also don't need to fix it to the correct node-type, as eslint itself takes care about ExperimentalSpreadProperty