### PR TITLE
Remove visiting of properties left of spread, fixes #249.

### DIFF
--- a/index.js
+++ b/index.js
@@ -320,18 +320,6 @@ function monkeypatch() {
         if (typeAnnotation) {
           checkIdentifierOrVisit.call(this, typeAnnotation);
         }
-        if (id.type === "ObjectPattern") {
-          // check if object destructuring has a spread
-          var hasSpread = id.properties.filter(function(p) {
-            return p._babelType === "SpreadProperty" || p._babelType === "RestProperty";
-          });
-          // visit properties if so
-          if (hasSpread.length > 0) {
-            for (var j = 0; j < id.properties.length; j++) {
-              this.visit(id.properties[j]);
-            }
-          }
-        }
       }
     }
     variableDeclaration.call(this, node);

--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -1137,18 +1137,45 @@ describe("verify", function () {
     );
   });
 
-  it("visits excluded properties left of spread #95", function () {
+  // This two tests are disabled, as the feature to visit properties when
+  // there is a spread/rest operator has been removed as it caused problems
+  // with other rules #249
+  it.skip("visits excluded properties left of spread #95", function () {
     verifyAndAssertMessages(
       "var originalObject = {}; var {field1, field2, ...clone} = originalObject;",
-      { "no-undef": 1, "no-unused-vars": 1, "no-redeclare": 1 },
+      { "no-unused-vars": 1 },
       []
     );
   });
 
-  it("visits excluded properties left of spread #210", function () {
+  it.skip("visits excluded properties left of spread #210", function () {
     verifyAndAssertMessages(
       "const props = { yo: 'yo' }; const { ...otherProps } = props;",
-      { "no-undef": 1, "no-unused-vars": 1, "no-redeclare": 1 },
+      { "no-unused-vars": 1 },
+      []
+    );
+  });
+
+  it("does not mark spread variables false-positive", function () {
+    verifyAndAssertMessages(
+      "var originalObject = {}; var {field1, field2, ...clone} = originalObject;",
+      { "no-undef": 1, "no-redeclare": 1 },
+      []
+    );
+  });
+
+  it("does not mark spread variables false-positive", function () {
+    verifyAndAssertMessages(
+      "const props = { yo: 'yo' }; const { ...otherProps } = props;",
+      { "no-undef": 1, "no-redeclare": 1 },
+      []
+    );
+  });
+
+  it("does not mark spread variables as use-before-define #249", function () {
+    verifyAndAssertMessages(
+      "var originalObject = {}; var {field1, field2, ...clone} = originalObject;",
+      { "no-use-before-define": 1 },
       []
     );
   });


### PR DESCRIPTION
I was trying hard to get both #95 and #249 working together, but I couldn't find a way that does not involve cheating by changing line/column numbers of nodes.

Maybe the best solution for now is to revert #95 and make sure that at least the core eslint stuff is working (and also eslint with espree is no doing the "visit properties left of spread"). Reverting #95 is what I did in this PR.

If someone finds a way of doing #95 without breaking #249 again, it can also be done later, but I think it is more important to make sure all rules work as expected.