### PR TITLE
Fix: Improve monkeypatching for ESLint v2.3.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ function monkeypatch() {
     estraverses.push(estraverseFb);
     assign(estraverseFb.VisitorKeys, t.VISITOR_KEYS);
   } catch (err) {
-    throw new Error("babel-eslint isn't currently compatible with ESLint 2.3.x. The recommendation is to pin to ESLint 2.2.x right now.");
+      // Ignore: ESLint v2.3.0 does not have estraverse-fb
   }
 
   // ESLint v1.9.0 uses estraverse directly to work around https://github.com/npm/npm/issues/9663
@@ -77,6 +77,7 @@ function monkeypatch() {
   escope.analyze = function (ast, opts) {
     opts.ecmaVersion = 6;
     opts.sourceType = "module";
+
     var results = analyze.call(this, ast, opts);
     return results;
   };
@@ -349,8 +350,6 @@ function monkeypatch() {
     }
   };
 }
-
-exports.VisitorKeys = t.VISITOR_KEYS;
 
 exports.parse = function (code, options) {
   options = options || {};

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/babel/babel-eslint",
   "devDependencies": {
-    "eslint": "~2.2.0",
+    "eslint": "^2.4.0",
     "espree": "^3.0.0",
     "mocha": "^2.3.3"
   }


### PR DESCRIPTION
Since v2.3.0, ESLint came to use `keys` and `childVisitorKeys` options instead of extending `estraverse. VisitorKeys`.
ESLint team has the plan to add the ability which extends VisitorKeys into parser plugins, but it may take a long time.

So this PR improves monkey patching for those options.