### PR TITLE
Fix processing sourceType: script

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,6 @@ function monkeypatch() {
   var analyze = escope.analyze;
   escope.analyze = function (ast, opts) {
     opts.ecmaVersion = 6;
-    opts.sourceType = "module";
 
     var results = analyze.call(this, ast, opts);
     return results;

--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -2,27 +2,32 @@
 "use strict";
 var eslint = require("eslint");
 
-function verifyAndAssertMessages(code, rules, expectedMessages, sourceType) {
-  var messages = eslint.linter.verify(
-    code,
-    {
-      parser: require.resolve(".."),
-      rules: rules,
-      env: {
-        node: true,
-        es6: true
+function verifyAndAssertMessages(code, rules, expectedMessages, sourceType, overrideConfig) {
+  var config = {
+    parser: require.resolve(".."),
+    rules: rules,
+    env: {
+      node: true,
+      es6: true
+    },
+    parserOptions: {
+      ecmaVersion: 6,
+      ecmaFeatures: {
+        jsx: true,
+        experimentalObjectRestSpread: true,
+        globalReturn: true
       },
-      parserOptions: {
-        ecmaVersion: 6,
-        ecmaFeatures: {
-          jsx: true,
-          experimentalObjectRestSpread: true,
-          globalReturn: true
-        },
-        sourceType: sourceType || "module"
-      }
+      sourceType: sourceType || "module"
     }
-  );
+  }
+
+  if (overrideConfig) {
+    for (var key in overrideConfig) {
+      config[key] = overrideConfig[key]
+    }
+  }
+
+  var messages = eslint.linter.verify(code, config);
 
   if (messages.length !== expectedMessages.length) {
     throw new Error("Expected " + expectedMessages.length + " message(s), got " + messages.length + " " + JSON.stringify(messages));

--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -1142,6 +1142,32 @@ describe("verify", function () {
     );
   });
 
+  it("no-implicit-globals in script", function () {
+    verifyAndAssertMessages(
+      "var leakedGlobal = 1;",
+      { "no-implicit-globals": 1 },
+      [ "1:5 Implicit global variable, assign as global property instead. no-implicit-globals" ],
+      "script",
+      {
+        env: {},
+        parserOptions: { ecmaVersion: 6, sourceType: "script" }
+      }
+    );
+  });
+
+  it("no-implicit-globals in module", function () {
+    verifyAndAssertMessages(
+      "var leakedGlobal = 1;",
+      { "no-implicit-globals": 1 },
+      [],
+      "module",
+      {
+        env: {},
+        parserOptions: { ecmaVersion: 6, sourceType: "module" }
+      }
+    );
+  });
+
   // This two tests are disabled, as the feature to visit properties when
   // there is a spread/rest operator has been removed as it caused problems
   // with other rules #249


### PR DESCRIPTION
It seems like some recent version of babel-eslint broke the [no-implicit-globals](http://eslint.org/docs/rules/no-implicit-globals) rule.

I'm not sure what specific version, but I'll try to bisect to figure out when it happened.

That test case can be verified working when `parser: "babel-eslint"` is commented out and broken once enabled.

I've only dug in a little, but it seems like its an issue with the scope analysis. `context.getScope().variables` doesn't seem to be reporting the correct global variables in the script type case.

Thanks!