### PR TITLE
Add root: true to eslint config.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "rules": {
     "strict": 0,
     "no-underscore-dangle": 0,


### PR DESCRIPTION
This prevents taking user's eslint config files that are higher in the
directory structure into consideration.