### PR TITLE
Add configuration section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,21 @@ $ npm install eslint@2.x babel-eslint@6 --save-dev
 
 Check out the [ESLint docs](http://eslint.org/docs/rules/) for all possible rules.
 
+### Configuration
+
+`sourceType` can be set to `'module'`(default) or `'script'` if your code isn't using ECMAScript modules.
+
+**.eslintrc**
+
+```json
+{
+  "parser": "babel-eslint",
+  "parserOptions": {
+    "sourceType": "module"
+  }
+}
+```
+
 ### Run
 
 ```sh


### PR DESCRIPTION
I also wanted to add a note about ecmaVersion, but as babylon is in version 6+ always, I don't see a good reason to specify 5 at all. If someone wants ecmaVersion 5 this person could simple use ESLint without babel-eslint.

Making the ecmaVersion configurable might not have been necessary I think