### PR TITLE
add a message about using the default parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 **babel-eslint** allows you to lint **ALL** valid Babel code with the fantastic
 [ESLint](https://github.com/eslint/eslint).
 
-## Note: You don't need to use babel-eslint if you are only using ES6/ES2015. ESLint actually supports ES6/ES7, JSX, and object rest/spread by default now.
+#### Note: You don't need to use babel-eslint if you are only using ES6/ES2015. ESLint actually supports ES6/ES7, JSX, and object rest/spread by default now.
 
-### You'll need it if you use stuff like class properties, decorators, async/await, types.
+##### At the moment, you'll need it if you use stuff like class properties, decorators, async/await, types.
 
 > If there is an issue, first check if it can be reproduced with the regular parser or with the latest versions of `eslint` and `babel-eslint`!
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 **babel-eslint** allows you to lint **ALL** valid Babel code with the fantastic
 [ESLint](https://github.com/eslint/eslint).
 
-`babel-eslint` is successfully linting babel and many other projects.
+## Note: You don't need to use babel-eslint if you are only using ES6/ES2015. ESLint actually supports ES6/ES7, JSX, and object rest/spread by default now.
+
+### You'll need it if you use stuff like class properties, decorators, async/await, types.
 
 > If there is an issue, first check if it can be reproduced with the regular parser or with the latest versions of `eslint` and `babel-eslint`!
 


### PR DESCRIPTION
just wanted to add something like this

Would be useful for most people given I think a lot of folks still think they have to use babel-eslint when they don't have to. ESLint supports ES6 and I still see people thinking it doesn't (same with JSHint even)