### PR TITLE
Reset TypeParameters to Identifier

### DIFF
--- a/babylon-to-espree/toAST.js
+++ b/babylon-to-espree/toAST.js
@@ -167,6 +167,12 @@ var astTransformVisitor = {
       node.type = "Experimental" + node.type;
     }
 
+    if (path.isTypeParameter && path.isTypeParameter()) {
+      node.type = "Identifier";
+      node.typeAnnotation = node.bound;
+      delete node.bound;
+    }
+
     // flow: prevent "no-undef"
     // for "Component" in: "let x: React.Component"
     if (path.isQualifiedTypeIdentifier()) {

--- a/index.js
+++ b/index.js
@@ -250,7 +250,8 @@ function monkeypatch() {
       this.close(node);
     }
   };
-    // visit decorators that are in: Property / MethodDefinition
+
+  // visit decorators that are in: Property / MethodDefinition
   var visitProperty = referencer.prototype.visitProperty;
   referencer.prototype.visitProperty = function(node) {
     if (node.value && node.value.type === "TypeCastExpression") {

--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -396,7 +396,7 @@ describe("verify", function () {
       );
     });
 
-    it.skip("polymorphpic/generic types - outside of fn scope #123", function () {
+    it("polymorphpic/generic types - outside of fn scope #123", function () {
       verifyAndAssertMessages([
           "export function foo<T>(value) { value; };",
           "var b: T = 1; b;"
@@ -407,7 +407,7 @@ describe("verify", function () {
       );
     });
 
-    it.skip("polymorphpic/generic types - extending unknown #123", function () {
+    it("polymorphpic/generic types - extending unknown #123", function () {
       verifyAndAssertMessages([
           "import Bar from 'bar';",
           "export class Foo extends Bar<T> {}",
@@ -786,7 +786,7 @@ describe("verify", function () {
       );
     });
 
-    it.skip("32", function () {
+    it("32", function () {
       verifyAndAssertMessages(
         [
           "import type Foo from 'foo';",


### PR DESCRIPTION
The new TypeParameter is currently not known by babel-eslint or eslint, so this fixes it by simply making it a Identifier again.

This could probably also have been done by doing more monkeypatching and making escope aware that TypeParameter exists and can be visited.

I also enabled some tests that were skipped, but are now working as it seems.