### PR TITLE
Add allowImportExportEverywhere parserOption (#327)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Check out the [ESLint docs](http://eslint.org/docs/rules/) for all possible rule
 ### Configuration
 
 `sourceType` can be set to `'module'`(default) or `'script'` if your code isn't using ECMAScript modules.
+`allowImportExportEverywhere` can be set to true to allow import and export declarations to appear anywhere a statement is allowed if your build environment supports that. By default, import and export declarations can only appear at a program's top level.
 
 **.eslintrc**
 
@@ -77,7 +78,8 @@ Check out the [ESLint docs](http://eslint.org/docs/rules/) for all possible rule
 {
   "parser": "babel-eslint",
   "parserOptions": {
-    "sourceType": "module"
+    "sourceType": "module",
+    "allowImportExportEverywhere": false
   }
 }
 ```

--- a/index.js
+++ b/index.js
@@ -365,6 +365,7 @@ exports.parse = function (code, options) {
   options = options || {};
   eslintOptions.ecmaVersion = options.ecmaVersion = options.ecmaVersion || 6;
   eslintOptions.sourceType = options.sourceType = options.sourceType || "module";
+  eslintOptions.allowImportExportEverywhere = options.allowImportExportEverywhere = options.allowImportExportEverywhere || false;
   if (options.sourceType === "module") {
     eslintOptions.globalReturn = false;
   } else {
@@ -385,7 +386,7 @@ exports.parseNoPatch = function (code, options) {
   var opts = {
     sourceType: options.sourceType,
     strictMode: true,
-    allowImportExportEverywhere: false, // consistent with espree
+    allowImportExportEverywhere: options.allowImportExportEverywhere, // consistent with espree
     allowReturnOutsideFunction: true,
     allowSuperOutsideMethod: true,
     plugins: [

--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -1435,6 +1435,22 @@ describe("verify", function () {
     );
   });
 
+  it("allowImportExportEverywhere option (#327)", function () {
+    verifyAndAssertMessages([
+        "if (true) { import Foo from 'foo'; }",
+        "function foo() { import Bar from 'bar'; }",
+        "switch (a) { case 1: import FooBar from 'foobar'; }"
+      ].join("\n"),
+      {},
+      [],
+      "module",
+      {
+        env: {},
+        parserOptions: { ecmaVersion: 6, sourceType: "module", allowImportExportEverywhere: true }
+      }
+    );
+  });
+
   it("with does not crash parsing in script mode (strict off) #171", function () {
     verifyAndAssertMessages(
       "with (arguments) { length; }",


### PR DESCRIPTION
This implements #327 by creating a new parserOption, "allowImportExportEverywhere", that defaults to false and is passed through to babylon.