### PR TITLE
remove hardcoded strict mode value

### DIFF
--- a/index.js
+++ b/index.js
@@ -385,7 +385,6 @@ exports.parse = function (code, options) {
 exports.parseNoPatch = function (code, options) {
   var opts = {
     sourceType: options.sourceType,
-    strictMode: true,
     allowImportExportEverywhere: options.allowImportExportEverywhere, // consistent with espree
     allowReturnOutsideFunction: true,
     allowSuperOutsideMethod: true,


### PR DESCRIPTION
In babylon

`this.strict = options.strictMode === false ? false : options.sourceType === "module";`

So  can rely on sourceType as the backup

https://github.com/babel/babylon/blob/cde17b33bd6a42fe73289873e3ef62bad2884481/src/tokenizer/state.js#L9