### PR TITLE
Rename ClassProperty.key instead of deleting it

### DIFF
--- a/babylon-to-espree/toAST.js
+++ b/babylon-to-espree/toAST.js
@@ -208,6 +208,7 @@ var astTransformVisitor = {
 
     // remove class property keys (or patch in escope)
     if (path.isClassProperty()) {
+      node._key = node.key;
       delete node.key;
     }
 


### PR DESCRIPTION
The no-undef rule uses escope which blindly looks for a key attribute in order to know if something is in scope. Right now the fix is to delete the key attribute but I need it for a rule I'm writing at Facebook. Instead of deleting it, just renaming it to _key works.

For context, the rule I'm writing is checking if a bound function using property initializer is not needed. We're going to use this for our React.createClass to es6 class migration in Facebook codebase.

Test Plan:
All the tests run fine.