### PR TITLE
Fix: improve handling of class properties (fixes #337)

### DIFF
--- a/index.js
+++ b/index.js
@@ -229,13 +229,6 @@ function monkeypatch() {
   // visit decorators that are in: ClassDeclaration / ClassExpression
   var visitClass = referencer.prototype.visitClass;
   referencer.prototype.visitClass = function(node) {
-    var classBody = node.body.body;
-    for (var a = 0; a < classBody.length; a++) {
-      if (classBody[a].type === "ClassProperty") {
-        createScopeVariable.call(this, classBody[a], classBody[a].key);
-      }
-    }
-
     visitDecorators.call(this, node);
     var typeParamScope;
     if (node.typeParameters) {
@@ -266,6 +259,14 @@ function monkeypatch() {
     }
     visitDecorators.call(this, node);
     visitProperty.call(this, node);
+  };
+
+  // visit ClassProperty as a Property.
+  referencer.prototype.ClassProperty = function(node) {
+    if (node.typeAnnotation) {
+      visitTypeAnnotation.call(this, node.typeAnnotation);
+    }
+    this.visitProperty(node);
   };
 
   // visit flow type in FunctionDeclaration, FunctionExpression, ArrowFunctionExpression

--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -1525,6 +1525,54 @@ describe("verify", function () {
     );
   });
 
+  describe("Class Property Declarations", function() {
+    it("no-redeclare false positive 1", function() {
+      verifyAndAssertMessages(
+        [
+          "class Group {",
+          "  static propTypes = {};",
+          "}",
+          "class TypicalForm {",
+          "  static propTypes = {};",
+          "}"
+        ].join("\n"),
+        { "no-redeclare": 1 },
+        []
+      );
+    });
+
+    it("no-redeclare false positive 2", function() {
+      verifyAndAssertMessages(
+        [
+          "function validate() {}",
+          "class MyComponent {",
+          "  static validate = validate;",
+          "}"
+        ].join("\n"),
+        { "no-redeclare": 1 },
+        []
+      );
+    });
+
+    it("check references", function() {
+      verifyAndAssertMessages(
+        [
+          "var a;",
+          "class A {",
+          "  prop1;",
+          "  prop2 = a;",
+          "  prop3 = b;",
+          "}",
+          "new A"
+        ].join("\n"),
+        { "no-undef": 1, "no-unused-vars": 1, "no-redeclare": 1 },
+        [
+          "5:11 'b' is not defined. no-undef"
+        ]
+      );
+    });
+  });
+
   // it("regex with es6 unicodeCodePointEscapes", function () {
   //   verifyAndAssertMessages(
   //     "string.replace(/[\u{0000A0}-\u{10FFFF}<>\&]/gmiu, (char) => `&#x${char.codePointAt(0).toString(16)};`);",


### PR DESCRIPTION
Fixes #337.

I added ClassProperty method into Referencer of escope. This method will address class properties and those type anotations.

I'm not sure tests are enough.