### PR TITLE
Visit method/function parameter decorators

### DIFF
--- a/index.js
+++ b/index.js
@@ -283,6 +283,7 @@ function monkeypatch() {
     if (node.params) {
       for (var i = 0; i < node.params.length; i++) {
         var param = node.params[i];
+        visitDecorators.call(this, param);
         if (param.typeAnnotation) {
           checkIdentifierOrVisit.call(this, param);
         } else if (t.isAssignmentPattern(param)) {


### PR DESCRIPTION
This makes `no-unused-vars` rule work well with method/function parameter decorators.

For example, eslint without this patch says `error  'Attribute' is defined but never used  no-unused-vars` for the following code:

``` js
import { Component, Attribute } from '@angular/core';

@Component({
  selector: 'hello',
  template: '<p>{{ name }}</p>',
})
class Hello {
  constructor(@Attribute('name') name) {
    this.name = name;
  }
}
```

This depends on https://github.com/babel/babel/pull/3665.
