### PR TITLE
Remove the lodash.assign dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 var babylonToEspree = require("./babylon-to-espree");
-var assign         = require("lodash.assign");
 var pick           = require("lodash.pickby");
 var Module         = require("module");
 var path           = require("path");
@@ -54,13 +53,13 @@ function monkeypatch() {
   // monkeypatch estraverse
   estraverse = estraverseRelative.require("estraverse");
   estraverses.push(estraverse);
-  assign(estraverse.VisitorKeys, t.VISITOR_KEYS);
+  Object.assign(estraverse.VisitorKeys, t.VISITOR_KEYS);
 
   // monkeypatch estraverse-fb (only for eslint < 2.3.0)
   try {
     var estraverseFb = eslintMod.require("estraverse-fb");
     estraverses.push(estraverseFb);
-    assign(estraverseFb.VisitorKeys, t.VISITOR_KEYS);
+    Object.assign(estraverseFb.VisitorKeys, t.VISITOR_KEYS);
   } catch (err) {
       // Ignore: ESLint v2.3.0 does not have estraverse-fb
   }
@@ -69,7 +68,7 @@ function monkeypatch() {
   var estraverseOfEslint = eslintMod.require("estraverse");
   if (estraverseOfEslint !== estraverseFb) {
     estraverses.push(estraverseOfEslint);
-    assign(estraverseOfEslint.VisitorKeys, t.VISITOR_KEYS);
+    Object.assign(estraverseOfEslint.VisitorKeys, t.VISITOR_KEYS);
   }
 
   estraverses.forEach(function (estraverse) {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "babel-traverse": "^6.0.20",
     "babel-types": "^6.0.19",
     "babylon": "^6.11.2",
-    "lodash.assign": "^4.0.0",
     "lodash.pickby": "^4.0.0"
   },
   "scripts": {

--- a/test/integration.js
+++ b/test/integration.js
@@ -1,5 +1,4 @@
 var assert = require("assert");
-var assign = require("lodash.assign");
 var eslint = require("eslint");
 var fs = require("fs");
 var path = require("path");
@@ -56,7 +55,7 @@ function strictSuite () {
   var ruleId = "strict";
 
   describe("when set to 'never'", function () {
-    var eslintOpts = assign({}, baseEslintOpts, {
+    var eslintOpts = Object.assign({}, baseEslintOpts, {
       rules: {},
     });
     eslintOpts.rules[ruleId] = [errorLevel, "never"];
@@ -81,7 +80,7 @@ function strictSuite () {
   // describe
 
   describe("when set to 'global'", function () {
-    var eslintOpts = assign({}, baseEslintOpts, {
+    var eslintOpts = Object.assign({}, baseEslintOpts, {
       rules: {}
     });
     eslintOpts.rules[ruleId] = [errorLevel, "global"];
@@ -145,7 +144,7 @@ function strictSuite () {
   // describe
 
   describe("when set to 'function'", function () {
-    var eslintOpts = assign({}, baseEslintOpts, {
+    var eslintOpts = Object.assign({}, baseEslintOpts, {
       rules: {}
     });
     eslintOpts.rules[ruleId] = [errorLevel, "function"];


### PR DESCRIPTION
lodash.assign is deprecated:
```
npm WARN deprecated lodash.assign@4.2.0: This package is deprecated. Use Object.assign.
```