### PR TITLE
Now using template strings

### DIFF
--- a/babylon-to-espree/toAST.js
+++ b/babylon-to-espree/toAST.js
@@ -160,7 +160,7 @@ var astTransformVisitor = {
     }
 
     if (path.isRestProperty() || path.isSpreadProperty()) {
-      node.type = "Experimental" + node.type;
+      node.type = `Experimental${node.type}`;
     }
 
     if (path.isTypeParameter && path.isTypeParameter()) {

--- a/babylon-to-espree/toToken.js
+++ b/babylon-to-espree/toToken.js
@@ -53,7 +53,7 @@ module.exports = function (token, tt, source) {
       pattern: value.pattern,
       flags: value.flags
     };
-    token.value = "/" + value.pattern + "/" + value.flags;
+    token.value = `/${value.pattern}/${value.flags}`;
   }
 
   return token;

--- a/index.js
+++ b/index.js
@@ -396,7 +396,7 @@ exports.parseNoPatch = function (code, options) {
       err.column = err.loc.column + 1;
 
       // remove trailing "(LINE:COLUMN)" acorn message and add in esprima syntax error message start
-      err.message = "Line " + err.lineNumber + ": " + err.message.replace(/ \((\d+):(\d+)\)$/, "");
+      err.message = `Line ${err.lineNumber}: ${err.message.replace(/ \((\d+):(\d+)\)$/, "")}`;
     }
 
     throw err;

--- a/test/babel-eslint.js
+++ b/test/babel-eslint.js
@@ -2,6 +2,7 @@ var assert      = require("assert");
 var babelEslint = require("..");
 var espree      = require("espree");
 var util        = require("util");
+var unpad       = require("../utils/unpad");
 
 // Checks if the source ast implements the target ast. Ignores extra keys on source ast
 function assertImplementsAST(target, source, path) {
@@ -70,11 +71,12 @@ function parseAndAssertSame(code) {
     if (babylonAST.tokens) {
       delete babylonAST.tokens;
     }
-    err.message += `
+    err.message += unpad(`
       espree:
       ${util.inspect(lookup(esAST, traversal, 2), {depth: err.depth, colors: true})}
       babel-eslint:
-      ${util.inspect(lookup(babylonAST, traversal, 2), {depth: err.depth, colors: true})}`;
+      ${util.inspect(lookup(babylonAST, traversal, 2), {depth: err.depth, colors: true})}
+    `);
     throw err;
   }
   // assert.equal(esAST, babylonAST);
@@ -132,24 +134,28 @@ describe("babylon-to-esprima", function () {
 
     it("template also with braces #96", function () {
       parseAndAssertSame(
-        `export default function f1() {
-          function f2(foo) {
-            const bar = 3;
-            return \`\${foo} \${bar}\`;
+        unpad(`
+          export default function f1() {
+            function f2(foo) {
+              const bar = 3;
+              return \`\${foo} \${bar}\`;
+            }
+            return f2;
           }
-          return f2;
-        }`
+        `)
       );
     });
 
     it("template with destructuring #31", function () {
       parseAndAssertSame(
-        `module.exports = {
-          render() {
-            var {name} = this.props;
-            return Math.max(null, \`Name: \${name}, Name: \${name}\`);
-          }
-        };`
+        unpad(`
+          module.exports = {
+            render() {
+              var {name} = this.props;
+              return Math.max(null, \`Name: \${name}, Name: \${name}\`);
+            }
+          };
+        `)
       );
     });
   });
@@ -252,30 +258,38 @@ describe("babylon-to-esprima", function () {
 
   it("line comments", function () {
     parseAndAssertSame(
-      `// single comment\nvar foo = 15; // comment next to statement
-      // second comment after statement`
+      unpad(`
+        // single comment
+        var foo = 15; // comment next to statement
+        // second comment after statement
+      `)
     );
   });
 
   it("block comments", function () {
     parseAndAssertSame(
-      `  /* single comment */\nvar foo = 15; /* comment next to statement */
-      /*
-       * multiline
-       * comment
-       */`
+      unpad(`
+        /* single comment */
+        var foo = 15; /* comment next to statement */
+        /*
+         * multiline
+         * comment
+         */
+       `)
     );
   });
 
   it("block comments #124", function () {
     parseAndAssertSame(
-      `React.createClass({
-        render() {
-          // return (
-          //   <div />
-          // ); // <-- this is the line that is reported
-        }
-      });`
+      unpad(`
+        React.createClass({
+          render() {
+            // return (
+            //   <div />
+            // ); // <-- this is the line that is reported
+          }
+        });
+      `)
     );
   });
 
@@ -305,34 +319,41 @@ describe("babylon-to-esprima", function () {
 
   it("jsdoc", function () {
     parseAndAssertSame(
-      `/**
-      * @param {object} options
-      * @return {number}
-      */\nconst test = function({ a, b, c }) {
-        return a + b + c;
-      };
-      module.exports = test;`
+      unpad(`
+        /**
+        * @param {object} options
+        * @return {number}
+        */
+        const test = function({ a, b, c }) {
+          return a + b + c;
+        };
+        module.exports = test;
+      `)
     );
   });
 
   it("empty block with comment", function () {
     parseAndAssertSame(
-      `function a () {
-        try {
-          b();
-        } catch (e) {
-          // asdf
+      unpad(`
+        function a () {
+          try {
+            b();
+          } catch (e) {
+            // asdf
+          }
         }
-      }`
+      `)
     );
   });
 
   describe("babel 6 tests", function () {
     it("MethodDefinition", function () {
       parseAndAssertSame(
-        `export default class A {
-          a() {}
-        }`
+        unpad(`
+          export default class A {
+            a() {}
+          }
+        `)
       );
     });
 
@@ -342,35 +363,41 @@ describe("babylon-to-esprima", function () {
 
     it("ClassMethod", function () {
       parseAndAssertSame(
-        `class A {
-          constructor() {
+        unpad(`
+          class A {
+            constructor() {
+            }
           }
-        }`
+        `)
       );
     });
 
     it("ClassMethod multiple params", function () {
       parseAndAssertSame(
-        `class A {
-          constructor(a, b, c) {
+        unpad(`
+          class A {
+            constructor(a, b, c) {
+            }
           }
-        }`
+        `)
       );
     });
 
     it("ClassMethod multiline", function () {
       parseAndAssertSame(
-        `class A {
-          constructor (
-            a,
-            b,
-            c
-          )
+        unpad(`
+          class A {
+            constructor (
+              a,
+              b,
+              c
+            )
 
-          {
+            {
 
+            }
           }
-        }`
+        `)
       );
     });
 
@@ -380,10 +407,12 @@ describe("babylon-to-esprima", function () {
 
     it("ObjectMethod", function () {
       parseAndAssertSame(
-        `var a = {
-          b(c) {
+        unpad(`
+          var a = {
+            b(c) {
+            }
           }
-        }`
+        `)
       );
     });
 
@@ -410,33 +439,39 @@ describe("babylon-to-esprima", function () {
     it("getters and setters", function () {
       parseAndAssertSame("class A { get x ( ) { ; } }");
       parseAndAssertSame(
-        `class A {
-          get x(
-          )
-          {
-            ;
+        unpad(`
+          class A {
+            get x(
+            )
+            {
+              ;
+            }
           }
-        }`
+        `)
       );
       parseAndAssertSame("class A { set x (a) { ; } }");
       parseAndAssertSame(
-        `class A {
-          set x(a
-          )
-          {
-            ;
+        unpad(`
+          class A {
+            set x(a
+            )
+            {
+              ;
+            }
           }
-        }`
+        `)
       );
       parseAndAssertSame(
-        `var B = {
-          get x () {
-            return this.ecks;
-          },
-          set x (ecks) {
-            this.ecks = ecks;
-          }
-        };`
+        unpad(`
+          var B = {
+            get x () {
+              return this.ecks;
+            },
+            set x (ecks) {
+              this.ecks = ecks;
+            }
+          };
+        `)
       );
     });
 
@@ -454,9 +489,11 @@ describe("babylon-to-esprima", function () {
 
     it("Async/Await", function() {
       parseAndAssertSame(
-        `async function a() {
-          await 1;
-        }`
+        unpad(`
+          async function a() {
+            await 1;
+          }
+        `)
       );
     });
   });

--- a/test/babel-eslint.js
+++ b/test/babel-eslint.js
@@ -252,16 +252,14 @@ describe("babylon-to-esprima", function () {
 
   it("line comments", function () {
     parseAndAssertSame(
-      `// single comment
-      var foo = 15; // comment next to statement
+      `// single comment\nvar foo = 15; // comment next to statement
       // second comment after statement`
     );
   });
 
   it("block comments", function () {
     parseAndAssertSame(
-      `  /* single comment */
-      var foo = 15; /* comment next to statement */
+      `  /* single comment */\nvar foo = 15; /* comment next to statement */
       /*
        * multiline
        * comment
@@ -310,8 +308,7 @@ describe("babylon-to-esprima", function () {
       `/**
       * @param {object} options
       * @return {number}
-      */
-      const test = function({ a, b, c }) {
+      */\nconst test = function({ a, b, c }) {
         return a + b + c;
       };
       module.exports = test;`

--- a/test/babel-eslint.js
+++ b/test/babel-eslint.js
@@ -10,7 +10,7 @@ function assertImplementsAST(target, source, path) {
   }
 
   function error(text) {
-    var err = new Error("At " + path.join(".") + ": " + text + ":");
+    var err = new Error(`At ${path.join(".")}: ${text}:`);
     err.depth = path.length + 1;
     throw err;
   }
@@ -18,7 +18,7 @@ function assertImplementsAST(target, source, path) {
   var typeA = target === null ? "null" : typeof target;
   var typeB = source === null ? "null" : typeof source;
   if (typeA !== typeB) {
-    error("have different types (" + typeA + " !== " + typeB + ") " + "(" + target + " !== " + source + ")");
+    error(`have different types (${typeA} !== ${typeB}) (${target} !== ${source})`);
   } else if (typeA === "object") {
     var keysTarget = Object.keys(target);
     for (var i in keysTarget) {
@@ -28,7 +28,7 @@ function assertImplementsAST(target, source, path) {
       path.pop();
     }
   } else if (target !== source) {
-    error("are different (" + JSON.stringify(target) + " !== " + JSON.stringify(source) + ")");
+    error(`are different (${JSON.stringify(target)} !== ${JSON.stringify(source)})`);
   }
 }
 
@@ -70,11 +70,11 @@ function parseAndAssertSame(code) {
     if (babylonAST.tokens) {
       delete babylonAST.tokens;
     }
-    err.message +=
-      "\nespree:\n" +
-      util.inspect(lookup(esAST, traversal, 2), {depth: err.depth, colors: true}) +
-      "\nbabel-eslint:\n" +
-      util.inspect(lookup(babylonAST, traversal, 2), {depth: err.depth, colors: true});
+    err.message += `
+      espree:
+      ${util.inspect(lookup(esAST, traversal, 2), {depth: err.depth, colors: true})}
+      babel-eslint:
+      ${util.inspect(lookup(babylonAST, traversal, 2), {depth: err.depth, colors: true})}`;
     throw err;
   }
   // assert.equal(esAST, babylonAST);
@@ -132,25 +132,25 @@ describe("babylon-to-esprima", function () {
 
     it("template also with braces #96", function () {
       parseAndAssertSame(
-        "export default function f1() {" +
-          "function f2(foo) {" +
-            "const bar = 3;" +
-            "return `${foo} ${bar}`;" +
-          "}" +
-          "return f2;" +
-        "}"
+        `export default function f1() {
+          function f2(foo) {
+            const bar = 3;
+            return \`\${foo} \${bar}\`;
+          }
+          return f2;
+        }`
       );
     });
 
     it("template with destructuring #31", function () {
-      parseAndAssertSame([
-        "module.exports = {",
-        "render() {",
-        "var {name} = this.props;",
-        "return Math.max(null, `Name: ${name}, Name: ${name}`);",
-        "}",
-        "};"
-      ].join("\n"));
+      parseAndAssertSame(
+        `module.exports = {
+          render() {
+            var {name} = this.props;
+            return Math.max(null, \`Name: \${name}, Name: \${name}\`);
+          }
+        };`
+      );
     });
   });
 
@@ -251,34 +251,34 @@ describe("babylon-to-esprima", function () {
   });
 
   it("line comments", function () {
-    parseAndAssertSame([
-      "  // single comment",
-      "var foo = 15; // comment next to statement",
-      "// second comment after statement"
-    ].join("\n"));
+    parseAndAssertSame(
+      `// single comment
+      var foo = 15; // comment next to statement
+      // second comment after statement`
+    );
   });
 
   it("block comments", function () {
-    parseAndAssertSame([
-      "  /* single comment */ ",
-      "var foo = 15; /* comment next to statement */",
-      "/*",
-      " * multiline",
-      " * comment",
-      " */"
-    ].join("\n"));
+    parseAndAssertSame(
+      `  /* single comment */
+      var foo = 15; /* comment next to statement */
+      /*
+       * multiline
+       * comment
+       */`
+    );
   });
 
   it("block comments #124", function () {
-    parseAndAssertSame([
-      "React.createClass({",
-      "render() {",
-      "// return (",
-      "//   <div />",
-      "// ); // <-- this is the line that is reported",
-      "}",
-      "});"
-    ].join("\n"));
+    parseAndAssertSame(
+      `React.createClass({
+        render() {
+          // return (
+          //   <div />
+          // ); // <-- this is the line that is reported
+        }
+      });`
+    );
   });
 
   it("null", function () {
@@ -306,76 +306,75 @@ describe("babylon-to-esprima", function () {
   });
 
   it("jsdoc", function () {
-    parseAndAssertSame([
-      "/**",
-      "* @param {object} options",
-      "* @return {number}",
-      "*/",
-      "const test = function({ a, b, c }) {",
-      "return a + b + c;",
-      "};",
-      "module.exports = test;"
-    ].join("\n"));
+    parseAndAssertSame(
+      `/**
+      * @param {object} options
+      * @return {number}
+      */
+      const test = function({ a, b, c }) {
+        return a + b + c;
+      };
+      module.exports = test;`
+    );
   });
 
   it("empty block with comment", function () {
-    parseAndAssertSame([
-      "function a () {",
-      "try {",
-      "b();",
-      "} catch (e) {",
-      "// asdf",
-      "}",
-      "}"
-    ].join("\n"));
+    parseAndAssertSame(
+      `function a () {
+        try {
+          b();
+        } catch (e) {
+          // asdf
+        }
+      }`
+    );
   });
 
   describe("babel 6 tests", function () {
     it("MethodDefinition", function () {
-      parseAndAssertSame([
-        "export default class A {",
-        "a() {}",
-        "}"
-      ].join("\n"));
+      parseAndAssertSame(
+        `export default class A {
+          a() {}
+        }`
+      );
     });
 
     it("MethodDefinition 2", function () {
-      parseAndAssertSame([
-        "export default class Bar { get bar() { return 42; }}"
-      ].join("\n"));
+      parseAndAssertSame("export default class Bar { get bar() { return 42; }}");
     });
 
     it("ClassMethod", function () {
-      parseAndAssertSame([
-        "class A {",
-        "constructor() {",
-        "}",
-        "}"
-      ].join("\n"));
+      parseAndAssertSame(
+        `class A {
+          constructor() {
+          }
+        }`
+      );
     });
 
     it("ClassMethod multiple params", function () {
-      parseAndAssertSame([
-        "class A {",
-        "constructor(a, b, c) {",
-        "}",
-        "}"
-      ].join("\n"));
+      parseAndAssertSame(
+        `class A {
+          constructor(a, b, c) {
+          }
+        }`
+      );
     });
 
     it("ClassMethod multiline", function () {
-      parseAndAssertSame([
-        "class A {",
-        "  constructor (",
-        "    a,",
-        "    b,",
-        "    c",
-        "  )",
-        "{",
-        "",
-        "  }",
-        "}"
-      ].join("\n"));
+      parseAndAssertSame(
+        `class A {
+          constructor (
+            a,
+            b,
+            c
+          )
+
+          {
+
+          }
+        }`
+      );
     });
 
     it("ClassMethod oneline", function () {
@@ -383,12 +382,12 @@ describe("babylon-to-esprima", function () {
     });
 
     it("ObjectMethod", function () {
-      parseAndAssertSame([
-        "var a = {",
-        "b(c) {",
-        "}",
-        "}"
-      ].join("\n"));
+      parseAndAssertSame(
+        `var a = {
+          b(c) {
+          }
+        }`
+      );
     });
 
     it("do not allow import export everywhere", function() {
@@ -413,35 +412,35 @@ describe("babylon-to-esprima", function () {
 
     it("getters and setters", function () {
       parseAndAssertSame("class A { get x ( ) { ; } }");
-      parseAndAssertSame([
-        "class A {",
-        "get x(",
-        ")",
-        "{",
-        ";",
-        "}",
-        "}"
-      ].join("\n"));
+      parseAndAssertSame(
+        `class A {
+          get x(
+          )
+          {
+            ;
+          }
+        }`
+      );
       parseAndAssertSame("class A { set x (a) { ; } }");
-      parseAndAssertSame([
-        "class A {",
-        "set x(a",
-        ")",
-        "{",
-        ";",
-        "}",
-        "}"
-      ].join("\n"));
-      parseAndAssertSame([
-        "var B = {",
-        "get x () {",
-        "return this.ecks;",
-        "},",
-        "set x (ecks) {",
-        "this.ecks = ecks;",
-        "}",
-        "};"
-      ].join("\n"));
+      parseAndAssertSame(
+        `class A {
+          set x(a
+          )
+          {
+            ;
+          }
+        }`
+      );
+      parseAndAssertSame(
+        `var B = {
+          get x () {
+            return this.ecks;
+          },
+          set x (ecks) {
+            this.ecks = ecks;
+          }
+        };`
+      );
     });
 
     it("RestOperator", function () {

--- a/test/integration.js
+++ b/test/integration.js
@@ -61,8 +61,7 @@ function strictSuite () {
     eslintOpts.rules[ruleId] = [errorLevel, "never"];
 
     ["global-with", "function-with"].forEach(function (fixture) {
-      it(
-        "should error on " + fixture.match(/^[^-]+/)[0] + " directive",
+      it(`should error on ${fixture.match(/^[^-]+/)[0]} directive`,
         function (done) {
           lint({
             fixture: ["strict", fixture],

--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -1,6 +1,7 @@
 /*eslint-env mocha*/
 "use strict";
 var eslint = require("eslint");
+var unpad = require("../utils/unpad");
 
 function verifyAndAssertMessages(code, rules, expectedMessages, sourceType, overrideConfig) {
   var config = {
@@ -36,10 +37,12 @@ function verifyAndAssertMessages(code, rules, expectedMessages, sourceType, over
   messages.forEach(function (message, i) {
     var formatedMessage = `${message.line}:${message.column} ${message.message}${(message.ruleId ? ` ${message.ruleId}` : "")}`;
     if (formatedMessage !== expectedMessages[i]) {
-      throw new Error(`
-        Message ${i} does not match:
-        Expected: ${expectedMessages[i]}
-        Actual:   ${formatedMessage}`
+      throw new Error(
+        unpad(`
+          Message ${i} does not match:
+          Expected: ${expectedMessages[i]}
+          Actual:   ${formatedMessage}
+        `)
       );
     }
   });
@@ -71,11 +74,13 @@ describe("verify", function () {
   });
 
   it("Modules support (issue #5)", function () {
-    verifyAndAssertMessages(`
-      import Foo from 'foo';
-      export default Foo;
-      export const c = 'c';
-      export class Store {}`,
+    verifyAndAssertMessages(
+      unpad(`
+        import Foo from 'foo';
+        export default Foo;
+        export const c = 'c';
+        export class Store {}
+      `),
       {},
       []
     );
@@ -164,11 +169,13 @@ describe("verify", function () {
   });
 
   it("comment with padded-blocks (issue #33)", function () {
-    verifyAndAssertMessages(`
-      if (a) {
-        // i'm a comment!
-        let b = c
-      }`,
+    verifyAndAssertMessages(
+      unpad(`
+        if (a) {
+          // i'm a comment!
+          let b = c
+        }
+      `),
       { "padded-blocks": [1, "never"] },
       []
     );
@@ -200,133 +207,157 @@ describe("verify", function () {
     });
 
     it("multiple nullable type annotations and return #108", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        import type Foo2 from 'foo';
-        import type Foo3 from 'foo';
-        function log(foo: ?Foo, foo2: ?Foo2): ?Foo3 {
-          console.log(foo, foo2);
-        }
-        log(1, 2);`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          import type Foo2 from 'foo';
+          import type Foo3 from 'foo';
+          function log(foo: ?Foo, foo2: ?Foo2): ?Foo3 {
+            console.log(foo, foo2);
+          }
+          log(1, 2);
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("type parameters", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        import type Foo2 from 'foo';
-        function log<T1, T2>(a: T1, b: T2) { return a + b; }
-        log<Foo, Foo2>(1, 2);`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          import type Foo2 from 'foo';
+          function log<T1, T2>(a: T1, b: T2) { return a + b; }
+          log<Foo, Foo2>(1, 2);
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("nested type annotations", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        function foo(callback: () => Foo) {
-          return callback();
-        }
-        foo();`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          function foo(callback: () => Foo) {
+            return callback();
+          }
+          foo();
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("type in var declaration", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        var x: Foo = 1;
-        x;`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          var x: Foo = 1;
+          x;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("object type annotation", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        var a: {numVal: Foo};
-        a;`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          var a: {numVal: Foo};
+          a;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("object property types", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        import type Foo2 from 'foo';
-        var a = {
-          circle: (null : ?{ setNativeProps(props: Foo): Foo2 })
-        };
-        a;`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          import type Foo2 from 'foo';
+          var a = {
+            circle: (null : ?{ setNativeProps(props: Foo): Foo2 })
+          };
+          a;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("namespaced types", function () {
-      verifyAndAssertMessages(`
-        var React = require('react-native');
-        var b = {
-          openExternalExample: (null: ?React.Component)
-        };
-        var c = {
-          render(): React.Component {}
-        };
-        b;
-        c;`,
+      verifyAndAssertMessages(
+        unpad(`
+          var React = require('react-native');
+          var b = {
+            openExternalExample: (null: ?React.Component)
+          };
+          var c = {
+            render(): React.Component {}
+          };
+          b;
+          c;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("ArrayTypeAnnotation", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        var x: Foo[]; x;`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          var x: Foo[]; x;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("ClassImplements", function () {
-      verifyAndAssertMessages(`
-        import type Bar from 'foo';
-        export default class Foo implements Bar {}`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Bar from 'foo';
+          export default class Foo implements Bar {}
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("type alias creates declaration + usage", function () {
-      verifyAndAssertMessages(`
-        type Foo = any;
-        var x : Foo = 1; x;`,
+      verifyAndAssertMessages(
+        unpad(`
+          type Foo = any;
+          var x : Foo = 1; x;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("type alias with type parameters", function () {
-      verifyAndAssertMessages(`
-        import type Bar from 'foo';
-        import type Foo3 from 'foo';
-        type Foo<T> = Bar<T, Foo3>
-        var x : Foo = 1; x;`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Bar from 'foo';
+          import type Foo3 from 'foo';
+          type Foo<T> = Bar<T, Foo3>
+          var x : Foo = 1; x;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("export type alias", function () {
-      verifyAndAssertMessages(`
-        import type Foo2 from 'foo';
-        export type Foo = Foo2;`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo2 from 'foo';
+          export type Foo = Foo2;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -341,150 +372,180 @@ describe("verify", function () {
     });
 
     it("types definition from import", function () {
-      verifyAndAssertMessages(`
-        import type Promise from 'bluebird';
-        type Operation = () => Promise;
-        x: Operation;`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Promise from 'bluebird';
+          type Operation = () => Promise;
+          x: Operation;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("polymorphpic/generic types for class #123", function () {
-      verifyAndAssertMessages(`
-        class Box<T> {
-          value: T;
-        }
-        var box = new Box();
-        console.log(box.value);`,
+      verifyAndAssertMessages(
+        unpad(`
+          class Box<T> {
+            value: T;
+          }
+          var box = new Box();
+          console.log(box.value);
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("polymorphpic/generic types for function #123", function () {
-      verifyAndAssertMessages(`
-        export function identity<T>(value) {
-          var a: T = value; a;
-        }`,
+      verifyAndAssertMessages(
+        unpad(`
+          export function identity<T>(value) {
+            var a: T = value; a;
+          }
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("polymorphpic/generic types for type alias #123", function () {
-      verifyAndAssertMessages(`
-        import Bar from './Bar';
-        type Foo<T> = Bar<T>; var x: Foo = 1; console.log(x);`,
+      verifyAndAssertMessages(
+        unpad(`
+          import Bar from './Bar';
+          type Foo<T> = Bar<T>; var x: Foo = 1; console.log(x);
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("polymorphpic/generic types - outside of fn scope #123", function () {
-      verifyAndAssertMessages(`
-        export function foo<T>(value) { value; };
-        var b: T = 1; b;`,
+      verifyAndAssertMessages(
+        unpad(`
+          export function foo<T>(value) { value; };
+          var b: T = 1; b;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
-        [ "2:29 'T' is defined but never used. no-unused-vars",
-          "3:16 'T' is not defined. no-undef" ]
+        [ "1:21 'T' is defined but never used. no-unused-vars",
+          "2:8 'T' is not defined. no-undef" ]
       );
     });
 
     it("polymorphpic/generic types - extending unknown #123", function () {
-      verifyAndAssertMessages(`
-        import Bar from 'bar';
-        export class Foo extends Bar<T> {}`,
+      verifyAndAssertMessages(
+        unpad(`
+          import Bar from 'bar';
+          export class Foo extends Bar<T> {}
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
-        [ "3:38 'T' is not defined. no-undef" ]
+        [ "2:30 'T' is not defined. no-undef" ]
       );
     });
 
     it("support declarations #132", function () {
-      verifyAndAssertMessages(`
-        declare class A { static () : number }
-        declare module B { declare var x: number; }
-        declare function foo<T>(): void;
-        declare var bar
-        A; B; foo(); bar;`,
+      verifyAndAssertMessages(
+        unpad(`
+          declare class A { static () : number }
+          declare module B { declare var x: number; }
+          declare function foo<T>(): void;
+          declare var bar
+          A; B; foo(); bar;
+        `),
         { "no-undef": 1, "no-unused-vars": 1 },
         []
       );
     });
 
     it("1", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        import type Foo2 from 'foo';
-        export default function(a: Foo, b: ?Foo2, c){ a; b; c; }`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          import type Foo2 from 'foo';
+          export default function(a: Foo, b: ?Foo2, c){ a; b; c; }
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("2", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        export default function(a: () => Foo){ a; }`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          export default function(a: () => Foo){ a; }
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("3", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        import type Foo2 from 'foo';
-        export default function(a: (_:Foo) => Foo2){ a; }`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          import type Foo2 from 'foo';
+          export default function(a: (_:Foo) => Foo2){ a; }
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("4", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        import type Foo2 from 'foo';
-        import type Foo3 from 'foo';
-        export default function(a: (_1:Foo, _2:Foo2) => Foo3){ a; }`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          import type Foo2 from 'foo';
+          import type Foo3 from 'foo';
+          export default function(a: (_1:Foo, _2:Foo2) => Foo3){ a; }
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("5", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        import type Foo2 from 'foo';
-        export default function(a: (_1:Foo, ...foo:Array<Foo2>) => number){ a; }`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          import type Foo2 from 'foo';
+          export default function(a: (_1:Foo, ...foo:Array<Foo2>) => number){ a; }
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("6", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        export default function(): Foo {}`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          export default function(): Foo {}
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("7", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        export default function():() => Foo {}`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          export default function():() => Foo {}
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("8", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        import type Foo2 from 'foo';
-        export default function():(_?:Foo) => Foo2{}`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          import type Foo2 from 'foo';
+          export default function():(_?:Foo) => Foo2{}
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -531,110 +592,132 @@ describe("verify", function () {
     });
 
     it("14", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        import type Foo2 from 'foo';
-        export default class Bar {set fooProp(value:Foo):Foo2{ value; }}`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          import type Foo2 from 'foo';
+          export default class Bar {set fooProp(value:Foo):Foo2{ value; }}
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("15", function () {
-      verifyAndAssertMessages(`
-        import type Foo2 from 'foo';
-        export default class Foo {get fooProp(): Foo2{}}`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo2 from 'foo';
+          export default class Foo {get fooProp(): Foo2{}}
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("16", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        var numVal:Foo; numVal;`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          var numVal:Foo; numVal;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("17", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        var a: {numVal: Foo;}; a;`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          var a: {numVal: Foo;}; a;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("18", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        import type Foo2 from 'foo';
-        import type Foo3 from 'foo';
-        var a: ?{numVal: Foo; [indexer: Foo2]: Foo3}; a;`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          import type Foo2 from 'foo';
+          import type Foo3 from 'foo';
+          var a: ?{numVal: Foo; [indexer: Foo2]: Foo3}; a;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("19", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        import type Foo2 from 'foo';
-        var a: {numVal: Foo; subObj?: ?{strVal: Foo2}}; a;`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          import type Foo2 from 'foo';
+          var a: {numVal: Foo; subObj?: ?{strVal: Foo2}}; a;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("20", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        import type Foo2 from 'foo';
-        import type Foo3 from 'foo';
-        import type Foo4 from 'foo';
-        var a: { [a: Foo]: Foo2; [b: Foo3]: Foo4; }; a;`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          import type Foo2 from 'foo';
+          import type Foo3 from 'foo';
+          import type Foo4 from 'foo';
+          var a: { [a: Foo]: Foo2; [b: Foo3]: Foo4; }; a;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("21", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        import type Foo2 from 'foo';
-        import type Foo3 from 'foo';
-        var a: {add(x:Foo, ...y:Array<Foo2>): Foo3}; a;`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          import type Foo2 from 'foo';
+          import type Foo3 from 'foo';
+          var a: {add(x:Foo, ...y:Array<Foo2>): Foo3}; a;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("22", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        import type Foo2 from 'foo';
-        import type Foo3 from 'foo';
-        var a: { id<Foo>(x: Foo2): Foo3; }; a;`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          import type Foo2 from 'foo';
+          import type Foo3 from 'foo';
+          var a: { id<Foo>(x: Foo2): Foo3; }; a;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("23", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        var a:Array<Foo> = [1, 2, 3]; a;`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          var a:Array<Foo> = [1, 2, 3]; a;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("24", function () {
-      verifyAndAssertMessages(`
-        import type Baz from 'baz';
-        export default class Bar<T> extends Baz<T> { };`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Baz from 'baz';
+          export default class Bar<T> extends Baz<T> { };
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -649,227 +732,275 @@ describe("verify", function () {
     });
 
     it("26", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        import type Foo2 from 'foo';
-        export default class Bar { static prop1:Foo; prop2:Foo2; }`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          import type Foo2 from 'foo';
+          export default class Bar { static prop1:Foo; prop2:Foo2; }
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("27", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        import type Foo2 from 'foo';
-        var x : Foo | Foo2 = 4; x;`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          import type Foo2 from 'foo';
+          var x : Foo | Foo2 = 4; x;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("28", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        import type Foo2 from 'foo';
-        var x : () => Foo | () => Foo2; x;`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          import type Foo2 from 'foo';
+          var x : () => Foo | () => Foo2; x;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("29", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        import type Foo2 from 'foo';
-        var x: typeof Foo | number = Foo2; x;`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          import type Foo2 from 'foo';
+          var x: typeof Foo | number = Foo2; x;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("30", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        var {x}: {x: Foo; } = { x: 'hello' }; x;`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          var {x}: {x: Foo; } = { x: 'hello' }; x;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("31", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        var [x]: Array<Foo> = [ 'hello' ]; x;`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          var [x]: Array<Foo> = [ 'hello' ]; x;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("32", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        export default function({x}: { x: Foo; }) { x; }`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          export default function({x}: { x: Foo; }) { x; }
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("33", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        function foo([x]: Array<Foo>) { x; } foo();`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          function foo([x]: Array<Foo>) { x; } foo();
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("34", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        import type Foo2 from 'foo';
-        var a: Map<Foo, Array<Foo2> >; a;`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          import type Foo2 from 'foo';
+          var a: Map<Foo, Array<Foo2> >; a;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("35", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        var a: ?Promise<Foo>[]; a;`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          var a: ?Promise<Foo>[]; a;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("36", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        import type Foo2 from 'foo';
-        var a:(...rest:Array<Foo>) => Foo2; a;`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          import type Foo2 from 'foo';
+          var a:(...rest:Array<Foo>) => Foo2; a;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("37", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        import type Foo2 from 'foo';
-        import type Foo3 from 'foo';
-        import type Foo4 from 'foo';
-        var a: <Foo>(x: Foo2, ...y:Foo3[]) => Foo4; a;`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          import type Foo2 from 'foo';
+          import type Foo3 from 'foo';
+          import type Foo4 from 'foo';
+          var a: <Foo>(x: Foo2, ...y:Foo3[]) => Foo4; a;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("38", function () {
-      verifyAndAssertMessages(`
-        import type {foo, bar} from 'baz';
-        foo; bar;`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type {foo, bar} from 'baz';
+          foo; bar;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("39", function () {
-      verifyAndAssertMessages(`
-        import type {foo as bar} from 'baz';
-        bar;`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type {foo as bar} from 'baz';
+          bar;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("40", function () {
-      verifyAndAssertMessages(`
-        import type from 'foo';
-        type;`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type from 'foo';
+          type;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("41", function () {
-      verifyAndAssertMessages(`
-        import type, {foo} from 'bar';
-        type; foo;`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type, {foo} from 'bar';
+          type; foo;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("42", function () {
-      verifyAndAssertMessages(`
-        import type * as namespace from 'bar';
-        namespace;`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type * as namespace from 'bar';
+          namespace;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("43", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        var a: Foo[]; a;`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          var a: Foo[]; a;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("44", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        var a: ?Foo[]; a;`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          var a: ?Foo[]; a;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("45", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        var a: (?Foo)[]; a;`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          var a: (?Foo)[]; a;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("46", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        var a: () => Foo[]; a;`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          var a: () => Foo[]; a;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("47", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        var a: (() => Foo)[]; a;`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          var a: (() => Foo)[]; a;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("48", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        var a: typeof Foo[]; a;`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          var a: typeof Foo[]; a;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("49", function () {
-      verifyAndAssertMessages(`
-        import type Foo from 'foo';
-        import type Foo2 from 'foo';
-        import type Foo3 from 'foo';
-        var a : [Foo, Foo2<Foo3>,] = [123, 'duck',]; a;`,
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from 'foo';
+          import type Foo2 from 'foo';
+          import type Foo3 from 'foo';
+          var a : [Foo, Foo2<Foo3>,] = [123, 'duck',]; a;
+        `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -885,12 +1016,14 @@ describe("verify", function () {
   });
 
   it("class definition: gaearon/redux#24", function () {
-    verifyAndAssertMessages(`
-      export default function root(stores) {
-      return DecoratedComponent => class ReduxRootDecorator {
-      a() { DecoratedComponent; stores; }
-      };
-      }`,
+    verifyAndAssertMessages(
+      unpad(`
+        export default function root(stores) {
+        return DecoratedComponent => class ReduxRootDecorator {
+        a() { DecoratedComponent; stores; }
+        };
+        }
+      `),
       { "no-undef": 1, "no-unused-vars": 1 },
       []
     );
@@ -913,13 +1046,15 @@ describe("verify", function () {
   });
 
   it("template with destructuring #31", function () {
-    verifyAndAssertMessages(`
-      module.exports = {
-      render() {
-      var {name} = this.props;
-      return Math.max(null, \`Name: \${name}, Name: \${name}\`);
-      }
-      };`,
+    verifyAndAssertMessages(
+      unpad(`
+        module.exports = {
+        render() {
+        var {name} = this.props;
+        return Math.max(null, \`Name: \${name}, Name: \${name}\`);
+        }
+        };
+      `),
       { "comma-spacing": 1 },
       []
     );
@@ -927,87 +1062,97 @@ describe("verify", function () {
 
   describe("decorators #72", function () {
     it("class declaration", function () {
-      verifyAndAssertMessages(`
-        import classDeclaration from 'decorator';
-        import decoratorParameter from 'decorator';
-        @classDeclaration((parameter) => parameter)
-        @classDeclaration(decoratorParameter)
-        @classDeclaration
-        export class TextareaAutosize {}`,
+      verifyAndAssertMessages(
+        unpad(`
+          import classDeclaration from 'decorator';
+          import decoratorParameter from 'decorator';
+          @classDeclaration((parameter) => parameter)
+          @classDeclaration(decoratorParameter)
+          @classDeclaration
+          export class TextareaAutosize {}
+        `),
         { "no-unused-vars": 1 },
         []
       );
     });
 
     it("method definition", function () {
-      verifyAndAssertMessages(`
-        import classMethodDeclarationA from 'decorator';
-        import decoratorParameter from 'decorator';
-        export class TextareaAutosize {
-        @classMethodDeclarationA((parameter) => parameter)
-        @classMethodDeclarationA(decoratorParameter)
-        @classMethodDeclarationA
-        methodDeclaration(e) {
-        e();
-        }
-        }`,
+      verifyAndAssertMessages(
+        unpad(`
+          import classMethodDeclarationA from 'decorator';
+          import decoratorParameter from 'decorator';
+          export class TextareaAutosize {
+          @classMethodDeclarationA((parameter) => parameter)
+          @classMethodDeclarationA(decoratorParameter)
+          @classMethodDeclarationA
+          methodDeclaration(e) {
+          e();
+          }
+          }
+        `),
         { "no-unused-vars": 1 },
         []
       );
     });
 
     it("method definition get/set", function () {
-      verifyAndAssertMessages(`
-        import classMethodDeclarationA from 'decorator';
-        import decoratorParameter from 'decorator';
-        export class TextareaAutosize {
-        @classMethodDeclarationA((parameter) => parameter)
-        @classMethodDeclarationA(decoratorParameter)
-        @classMethodDeclarationA
-        get bar() { }
-        @classMethodDeclarationA((parameter) => parameter)
-        @classMethodDeclarationA(decoratorParameter)
-        @classMethodDeclarationA
-        set bar(val) { val; }
-        }`,
+      verifyAndAssertMessages(
+        unpad(`
+          import classMethodDeclarationA from 'decorator';
+          import decoratorParameter from 'decorator';
+          export class TextareaAutosize {
+          @classMethodDeclarationA((parameter) => parameter)
+          @classMethodDeclarationA(decoratorParameter)
+          @classMethodDeclarationA
+          get bar() { }
+          @classMethodDeclarationA((parameter) => parameter)
+          @classMethodDeclarationA(decoratorParameter)
+          @classMethodDeclarationA
+          set bar(val) { val; }
+          }
+        `),
         { "no-unused-vars": 1 },
         []
       );
     });
 
     it("object property", function () {
-      verifyAndAssertMessages(`
-        import classMethodDeclarationA from 'decorator';
-        import decoratorParameter from 'decorator';
-        var obj = {
-        @classMethodDeclarationA((parameter) => parameter)
-        @classMethodDeclarationA(decoratorParameter)
-        @classMethodDeclarationA
-        methodDeclaration(e) {
-        e();
-        }
-        };
-        obj;`,
+      verifyAndAssertMessages(
+        unpad(`
+          import classMethodDeclarationA from 'decorator';
+          import decoratorParameter from 'decorator';
+          var obj = {
+          @classMethodDeclarationA((parameter) => parameter)
+          @classMethodDeclarationA(decoratorParameter)
+          @classMethodDeclarationA
+          methodDeclaration(e) {
+          e();
+          }
+          };
+          obj;
+        `),
         { "no-unused-vars": 1 },
         []
       );
     });
 
     it("object property get/set", function () {
-      verifyAndAssertMessages(`
-        import classMethodDeclarationA from 'decorator';
-        import decoratorParameter from 'decorator';
-        var obj = {
-        @classMethodDeclarationA((parameter) => parameter)
-        @classMethodDeclarationA(decoratorParameter)
-        @classMethodDeclarationA
-        get bar() { },
-        @classMethodDeclarationA((parameter) => parameter)
-        @classMethodDeclarationA(decoratorParameter)
-        @classMethodDeclarationA
-        set bar(val) { val; }
-        };
-        obj;`,
+      verifyAndAssertMessages(
+        unpad(`
+          import classMethodDeclarationA from 'decorator';
+          import decoratorParameter from 'decorator';
+          var obj = {
+          @classMethodDeclarationA((parameter) => parameter)
+          @classMethodDeclarationA(decoratorParameter)
+          @classMethodDeclarationA
+          get bar() { },
+          @classMethodDeclarationA((parameter) => parameter)
+          @classMethodDeclarationA(decoratorParameter)
+          @classMethodDeclarationA
+          set bar(val) { val; }
+          };
+          obj;
+        `),
         { "no-unused-vars": 1 },
         []
       );
@@ -1074,34 +1219,40 @@ describe("verify", function () {
   });
 
   it("don't warn no-unused-vars with spread #142", function () {
-    verifyAndAssertMessages(`
-      export default function test(data) {
-      return {
-      foo: 'bar',
-      ...data
-      };
-      }`,
+    verifyAndAssertMessages(
+      unpad(`
+        export default function test(data) {
+        return {
+        foo: 'bar',
+        ...data
+        };
+        }
+      `),
       { "no-undef": 1, "no-unused-vars": 1 },
       []
     );
   });
 
   it("excludes comment tokens #153", function () {
-    verifyAndAssertMessages(`
-      var a = [
-      1,
-      2, // a trailing comment makes this line fail comma-dangle (always-multiline)
-      ];`,
+    verifyAndAssertMessages(
+      unpad(`
+        var a = [
+        1,
+        2, // a trailing comment makes this line fail comma-dangle (always-multiline)
+        ];
+      `),
       { "comma-dangle": [2, "always-multiline"] },
       []
     );
 
-    verifyAndAssertMessages(`
-      switch (a) {
-      // A comment here makes the above line fail brace-style
-      case 1:
-      console.log(a);
-      }`,
+    verifyAndAssertMessages(
+      unpad(`
+        switch (a) {
+        // A comment here makes the above line fail brace-style
+        case 1:
+        console.log(a);
+        }
+      `),
       { "brace-style": 2 },
       []
     );
@@ -1116,30 +1267,34 @@ describe("verify", function () {
   });
 
   it("line comment space-in-parens #124", function () {
-    verifyAndAssertMessages(`
-      React.createClass({
-      render() {
-      // return (
-      //   <div />
-      // ); // <-- this is the line that is reported
-      }
-      });`,
+    verifyAndAssertMessages(
+      unpad(`
+        React.createClass({
+        render() {
+        // return (
+        //   <div />
+        // ); // <-- this is the line that is reported
+        }
+        });
+      `),
       { "space-in-parens": 1 },
       [ ]
     );
   });
 
   it("block comment space-in-parens #124", function () {
-    verifyAndAssertMessages(`
-      React.createClass({
-      render() {
-      /*
-      return (
-        <div />
-      ); // <-- this is the line that is reported
-      */
-      }
-      });`,
+    verifyAndAssertMessages(
+      unpad(`
+        React.createClass({
+        render() {
+        /*
+        return (
+          <div />
+        ); // <-- this is the line that is reported
+        */
+        }
+        });
+      `),
       { "space-in-parens": 1 },
       [ ]
     );
@@ -1160,28 +1315,32 @@ describe("verify", function () {
   });
 
   it("default param flow type no-unused-vars #184", function () {
-    verifyAndAssertMessages(`
-      type ResolveOptionType = {
-      depth?: number,
-      identifier?: string
-      };
+    verifyAndAssertMessages(
+      unpad(`
+        type ResolveOptionType = {
+        depth?: number,
+        identifier?: string
+        };
 
-      export default function resolve(
-      options: ResolveOptionType = {}
-      ): Object {
-      options;
-      }`,
+        export default function resolve(
+        options: ResolveOptionType = {}
+        ): Object {
+        options;
+        }
+      `),
       { "no-unused-vars": 1, "no-undef": 1 },
       [ ]
     );
   });
 
   it("no-use-before-define #192", function () {
-    verifyAndAssertMessages(`
-      console.log(x);
-      var x = 1;`,
+    verifyAndAssertMessages(
+      unpad(`
+        console.log(x);
+        var x = 1;
+      `),
       { "no-use-before-define": 1 },
-      [ "2:19 'x' was used before it was defined. no-use-before-define" ]
+      [ "1:13 'x' was used before it was defined. no-use-before-define" ]
     );
   });
 
@@ -1194,58 +1353,68 @@ describe("verify", function () {
   });
 
   it("getter/setter #218", function () {
-    verifyAndAssertMessages(`
-      class Person {
-          set a (v) { }
-      }`,
+    verifyAndAssertMessages(
+      unpad(`
+        class Person {
+            set a (v) { }
+        }
+      `),
       { "space-before-function-paren": 1, "keyword-spacing": [1, {"before": true}], "indent": 1 },
       []
     );
   });
 
   it("getter/setter #220", function () {
-    verifyAndAssertMessages(`
-      var B = {
-      get x () {
-      return this.ecks;
-      },
-      set x (ecks) {
-      this.ecks = ecks;
-      }
-      };`,
+    verifyAndAssertMessages(
+      unpad(`
+        var B = {
+        get x () {
+        return this.ecks;
+        },
+        set x (ecks) {
+        this.ecks = ecks;
+        }
+        };
+      `),
       { "no-dupe-keys": 1 },
       []
     );
   });
 
   it("fixes issues with flow types and ObjectPattern", function () {
-    verifyAndAssertMessages(`
-      import type Foo from 'bar';
-      export default class Foobar {
-        foo({ bar }: Foo) { bar; }
-        bar({ foo }: Foo) { foo; }
-      }`,
+    verifyAndAssertMessages(
+      unpad(`
+        import type Foo from 'bar';
+        export default class Foobar {
+          foo({ bar }: Foo) { bar; }
+          bar({ foo }: Foo) { foo; }
+        }
+      `),
       { "no-unused-vars": 1, "no-shadow": 1 },
       []
     );
   });
 
   it("correctly detects redeclares if in script mode #217", function () {
-    verifyAndAssertMessages(`
-      var a = 321;
-      var a = 123;`,
+    verifyAndAssertMessages(
+      unpad(`
+        var a = 321;
+        var a = 123;
+      `),
       { "no-redeclare": 1 },
-      [ "3:11 'a' is already defined. no-redeclare" ],
+      [ "2:5 'a' is already defined. no-redeclare" ],
       "script"
     );
   });
 
   it("correctly detects redeclares if in module mode #217", function () {
-    verifyAndAssertMessages(`
-      var a = 321;
-      var a = 123;`,
+    verifyAndAssertMessages(
+      unpad(`
+        var a = 321;
+        var a = 123;
+      `),
       { "no-redeclare": 1 },
-      [ "3:11 'a' is already defined. no-redeclare" ],
+      [ "2:5 'a' is already defined. no-redeclare" ],
       "module"
     );
   });
@@ -1290,10 +1459,12 @@ describe("verify", function () {
   });
 
   it("allowImportExportEverywhere option (#327)", function () {
-    verifyAndAssertMessages(`
-      if (true) { import Foo from 'foo'; }
-      function foo() { import Bar from 'bar'; }
-      switch (a) { case 1: import FooBar from 'foobar'; }`,
+    verifyAndAssertMessages(
+      unpad(`
+        if (true) { import Foo from 'foo'; }
+        function foo() { import Bar from 'bar'; }
+        switch (a) { case 1: import FooBar from 'foobar'; }
+      `),
       {},
       [],
       "module",
@@ -1330,44 +1501,53 @@ describe("verify", function () {
   });
 
   it("decorator does not create TypeError #229", function () {
-    verifyAndAssertMessages(`
-      class A {
-        @test
-        f() {}
-      }`,
+    verifyAndAssertMessages(
+      unpad(`
+        class A {
+          @test
+          f() {}
+        }
+      `),
       { "no-undef": 1 },
-      [ "3:10 'test' is not defined. no-undef" ]
+      [ "2:4 'test' is not defined. no-undef" ]
     );
   });
 
   it("Flow definition does not trigger warnings #223", function () {
-    verifyAndAssertMessages(`
-      import { Map as $Map } from 'immutable';
-      function myFunction($state: $Map, { a, b, c } : { a: ?Object, b: ?Object, c: $Map }) {}`,
+    verifyAndAssertMessages(
+      unpad(`
+        import { Map as $Map } from 'immutable';
+        function myFunction($state: $Map, { a, b, c } : { a: ?Object, b: ?Object, c: $Map }) {}
+      `),
       { "no-dupe-args": 1, "no-redeclare": 1, "no-shadow": 1 },
       []
     );
   });
 
   it("newline-before-return with comments #289", function () {
-    verifyAndAssertMessages(`
-      function a() {
-      if (b) {
-      /* eslint-disable no-console */
-      console.log('test');
-      /* eslint-enable no-console */
-      }
+    verifyAndAssertMessages(
+      unpad(`
+        function a() {
+        if (b) {
+        /* eslint-disable no-console */
+        console.log('test');
+        /* eslint-enable no-console */
+        }
 
-      return hasGlobal;
-      }`,
+        return hasGlobal;
+        }
+      `),
       { "newline-before-return": 1 },
       []
     );
   });
 
   it("spaced-comment with shebang #163", function () {
-    verifyAndAssertMessages(`#!/usr/bin/env babel-node
-      import {spawn} from 'foobar';`,
+    verifyAndAssertMessages(
+      unpad(`
+        #!/usr/bin/env babel-node
+        import {spawn} from 'foobar';
+      `),
       { "spaced-comment": 1 },
       []
     );
@@ -1375,41 +1555,47 @@ describe("verify", function () {
 
   describe("Class Property Declarations", function() {
     it("no-redeclare false positive 1", function() {
-      verifyAndAssertMessages(`
-        class Group {
-          static propTypes = {};
-        }
-        class TypicalForm {
-          static propTypes = {};
-        }`,
+      verifyAndAssertMessages(
+        unpad(`
+          class Group {
+            static propTypes = {};
+          }
+          class TypicalForm {
+            static propTypes = {};
+          }
+        `),
         { "no-redeclare": 1 },
         []
       );
     });
 
     it("no-redeclare false positive 2", function() {
-      verifyAndAssertMessages(`
-        function validate() {}
-        class MyComponent {
-          static validate = validate;
-        }`,
+      verifyAndAssertMessages(
+        unpad(`
+          function validate() {}
+          class MyComponent {
+            static validate = validate;
+          }
+        `),
         { "no-redeclare": 1 },
         []
       );
     });
 
     it("check references", function() {
-      verifyAndAssertMessages(`
-        var a;
-        class A {
-          prop1;
-          prop2 = a;
-          prop3 = b;
-        }
-        new A`,
+      verifyAndAssertMessages(
+        unpad(`
+          var a;
+          class A {
+            prop1;
+            prop2 = a;
+            prop3 = b;
+          }
+          new A
+        `),
         { "no-undef": 1, "no-unused-vars": 1, "no-redeclare": 1 },
         [
-          "6:19 'b' is not defined. no-undef"
+          "5:11 'b' is not defined. no-undef"
         ]
       );
     });

--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -68,10 +68,10 @@ describe("verify", function () {
 
   it("Modules support (issue #5)", function () {
     verifyAndAssertMessages(
-      "import Foo from 'foo';\n" +
-      "export default Foo;\n" +
-      "export const c = 'c';\n" +
-      "export class Store {}",
+      `import Foo from 'foo';
+      export default Foo;
+      export const c = 'c';
+      export class Store {}`,
       {},
       []
     );
@@ -160,12 +160,11 @@ describe("verify", function () {
   });
 
   it("comment with padded-blocks (issue #33)", function () {
-    verifyAndAssertMessages([
-      "if (a){",
-      "// i'm a comment!",
-      "let b = c",
-      "}"
-    ].join("\n"),
+    verifyAndAssertMessages(
+      `if (a) {
+        // i'm a comment!
+        let b = c
+      }`,
       { "padded-blocks": [1, "never"] },
       []
     );
@@ -173,9 +172,8 @@ describe("verify", function () {
 
   describe("flow", function () {
     it("check regular function", function () {
-      verifyAndAssertMessages([
+      verifyAndAssertMessages(
         "function a(b, c) { b += 1; c += 1; return b + c; } a;",
-      ].join("\n"),
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -198,233 +196,213 @@ describe("verify", function () {
     });
 
     it("multiple nullable type annotations and return #108", function () {
-      verifyAndAssertMessages([
-        "import type Foo from 'foo';",
-        "import type Foo2 from 'foo';",
-        "import type Foo3 from 'foo';",
-        "function log(foo: ?Foo, foo2: ?Foo2): ?Foo3 {",
-        "console.log(foo, foo2);",
-        "}",
-        "log(1, 2);"
-      ].join("\n"),
+      verifyAndAssertMessages(
+        `import type Foo from 'foo';
+        import type Foo2 from 'foo';
+        import type Foo3 from 'foo';
+        function log(foo: ?Foo, foo2: ?Foo2): ?Foo3 {
+          console.log(foo, foo2);
+        }
+        log(1, 2);`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("type parameters", function () {
-      verifyAndAssertMessages([
-        "import type Foo from 'foo';",
-        "import type Foo2 from 'foo';",
-        "function log<T1, T2>(a: T1, b: T2) { return a + b; }",
-        "log<Foo, Foo2>(1, 2);"
-      ].join("\n"),
+      verifyAndAssertMessages(
+        `import type Foo from 'foo';
+        import type Foo2 from 'foo';
+        function log<T1, T2>(a: T1, b: T2) { return a + b; }
+        log<Foo, Foo2>(1, 2);`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("nested type annotations", function () {
-      verifyAndAssertMessages([
-        "import type Foo from 'foo';",
-        "function foo(callback: () => Foo) {",
-        "return callback();",
-        "}",
-        "foo();"
-      ].join("\n"),
+      verifyAndAssertMessages(
+        `import type Foo from 'foo';
+        function foo(callback: () => Foo) {
+          return callback();
+        }
+        foo();`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("type in var declaration", function () {
-      verifyAndAssertMessages([
-        "import type Foo from 'foo';",
-        "var x: Foo = 1;",
-        "x;"
-      ].join("\n"),
+      verifyAndAssertMessages(
+        `import type Foo from 'foo';
+        var x: Foo = 1;
+        x;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("object type annotation", function () {
-      verifyAndAssertMessages([
-        "import type Foo from 'foo';",
-        "var a: {numVal: Foo};",
-        "a;"
-      ].join("\n"),
+      verifyAndAssertMessages(
+        `import type Foo from 'foo';
+        var a: {numVal: Foo};
+        a;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("object property types", function () {
-      verifyAndAssertMessages([
-        "import type Foo from 'foo';",
-        "import type Foo2 from 'foo';",
-        "var a = {",
-        "circle: (null : ?{ setNativeProps(props: Foo): Foo2 })",
-        "};",
-        "a;"
-      ].join("\n"),
+      verifyAndAssertMessages(
+        `import type Foo from 'foo';
+        import type Foo2 from 'foo';
+        var a = {
+          circle: (null : ?{ setNativeProps(props: Foo): Foo2 })
+        };
+        a;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("namespaced types", function () {
-      verifyAndAssertMessages([
-        "var React = require('react-native');",
-        "var b = {",
-        "openExternalExample: (null: ?React.Component)",
-        "};",
-        "var c = {",
-        "render(): React.Component {}",
-        "};",
-        "b;",
-        "c;"
-      ].join("\n"),
+      verifyAndAssertMessages(
+        `var React = require('react-native');
+        var b = {
+          openExternalExample: (null: ?React.Component)
+        };
+        var c = {
+          render(): React.Component {}
+        };
+        b;
+        c;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("ArrayTypeAnnotation", function () {
-      verifyAndAssertMessages([
-        "import type Foo from 'foo';",
-        "var x: Foo[]; x;"
-      ].join("\n"),
+      verifyAndAssertMessages(
+        `import type Foo from 'foo';
+        var x: Foo[]; x;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("ClassImplements", function () {
-      verifyAndAssertMessages([
-        "import type Bar from 'foo';",
-        "export default class Foo implements Bar {}"
-      ].join("\n"),
+      verifyAndAssertMessages(
+        `import type Bar from 'foo';
+        export default class Foo implements Bar {}`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("type alias creates declaration + usage", function () {
-      verifyAndAssertMessages([
-        "type Foo = any;",
-        "var x : Foo = 1; x;"
-      ].join("\n"),
+      verifyAndAssertMessages(
+        `type Foo = any;
+        var x : Foo = 1; x;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("type alias with type parameters", function () {
-      verifyAndAssertMessages([
-        "import type Bar from 'foo';",
-        "import type Foo3 from 'foo';",
-        "type Foo<T> = Bar<T, Foo3>",
-        "var x : Foo = 1; x;"
-      ].join("\n"),
+      verifyAndAssertMessages(
+        `import type Bar from 'foo';
+        import type Foo3 from 'foo';
+        type Foo<T> = Bar<T, Foo3>
+        var x : Foo = 1; x;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("export type alias", function () {
-      verifyAndAssertMessages([
-        "import type Foo2 from 'foo';",
-        "export type Foo = Foo2;"
-      ].join("\n"),
+      verifyAndAssertMessages(
+        `import type Foo2 from 'foo';
+        export type Foo = Foo2;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("polymorphpic types #109", function () {
-      verifyAndAssertMessages([
-        "export default function groupByEveryN<T>(array: Array<T>, n: number): Array<Array<?T>> { n; }"
-      ].join("\n"),
+      verifyAndAssertMessages(
+        "export default function groupByEveryN<T>(array: Array<T>, n: number): Array<Array<?T>> { n; }",
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("types definition from import", function () {
-      verifyAndAssertMessages([
-        "import type Promise from 'bluebird';",
-        "type Operation = () => Promise;",
-        "x: Operation;"
-      ].join("\n"),
+      verifyAndAssertMessages(
+        `import type Promise from 'bluebird';
+        type Operation = () => Promise;
+        x: Operation;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("polymorphpic/generic types for class #123", function () {
-      verifyAndAssertMessages([
-        "class Box<T> {",
-        "value: T;",
-        "}",
-        "var box = new Box();",
-        "console.log(box.value);"
-      ].join("\n"),
+      verifyAndAssertMessages(
+        `class Box<T> {
+          value: T;
+        }
+        var box = new Box();
+        console.log(box.value);`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("polymorphpic/generic types for function #123", function () {
-      verifyAndAssertMessages([
-        "export function identity<T>(value) {",
-        "var a: T = value; a;",
-        "}"
-      ].join("\n"),
+      verifyAndAssertMessages(
+        `export function identity<T>(value) {
+          var a: T = value; a;
+        }`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("polymorphpic/generic types for type alias #123", function () {
-      verifyAndAssertMessages([
-        "import Bar from './Bar';",
-        "type Foo<T> = Bar<T>; var x: Foo = 1; console.log(x);"
-      ].join("\n"),
+      verifyAndAssertMessages(
+        `import Bar from './Bar';
+        type Foo<T> = Bar<T>; var x: Foo = 1; console.log(x);`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
     });
 
     it("polymorphpic/generic types - outside of fn scope #123", function () {
-      verifyAndAssertMessages([
-        "export function foo<T>(value) { value; };",
-        "var b: T = 1; b;"
-      ].join("\n"),
+      verifyAndAssertMessages(
+        `export function foo<T>(value) { value; };
+        var b: T = 1; b;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         [ "1:21 'T' is defined but never used. no-unused-vars",
-          "2:8 'T' is not defined. no-undef" ]
+          "2:16 'T' is not defined. no-undef" ]
       );
     });
 
     it("polymorphpic/generic types - extending unknown #123", function () {
-      verifyAndAssertMessages([
-        "import Bar from 'bar';",
-        "export class Foo extends Bar<T> {}",
-      ].join("\n"),
+      verifyAndAssertMessages(
+        `import Bar from 'bar';
+        export class Foo extends Bar<T> {}`,
         { "no-unused-vars": 1, "no-undef": 1 },
-        [ "2:30 'T' is not defined. no-undef" ]
+        [ "2:38 'T' is not defined. no-undef" ]
       );
     });
 
     it("support declarations #132", function () {
-      verifyAndAssertMessages([
-        "declare class A { static () : number }",
-        "declare module B { declare var x: number; }",
-        "declare function foo<T>(): void;",
-        "declare var bar",
-        "A; B; foo(); bar;"
-      ].join("\n"),
+      verifyAndAssertMessages(
+        `declare class A { static () : number }
+        declare module B { declare var x: number; }
+        declare function foo<T>(): void;
+        declare var bar
+        A; B; foo(); bar;`,
         { "no-undef": 1, "no-unused-vars": 1 },
         []
       );
@@ -432,11 +410,9 @@ describe("verify", function () {
 
     it("1", function () {
       verifyAndAssertMessages(
-        [
-          "import type Foo from 'foo';",
-          "import type Foo2 from 'foo';",
-          "export default function(a: Foo, b: ?Foo2, c){ a; b; c; }"
-        ].join("\n"),
+        `import type Foo from 'foo';
+        import type Foo2 from 'foo';
+        export default function(a: Foo, b: ?Foo2, c){ a; b; c; }`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -444,10 +420,8 @@ describe("verify", function () {
 
     it("2", function () {
       verifyAndAssertMessages(
-        [
-          "import type Foo from 'foo';",
-          "export default function(a: () => Foo){ a; }"
-        ].join("\n"),
+        `import type Foo from 'foo';
+        export default function(a: () => Foo){ a; }`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -455,11 +429,9 @@ describe("verify", function () {
 
     it("3", function () {
       verifyAndAssertMessages(
-        [
-          "import type Foo from 'foo';",
-          "import type Foo2 from 'foo';",
-          "export default function(a: (_:Foo) => Foo2){ a; }"
-        ].join("\n"),
+        `import type Foo from 'foo';
+        import type Foo2 from 'foo';
+        export default function(a: (_:Foo) => Foo2){ a; }`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -467,12 +439,10 @@ describe("verify", function () {
 
     it("4", function () {
       verifyAndAssertMessages(
-        [
-          "import type Foo from 'foo';",
-          "import type Foo2 from 'foo';",
-          "import type Foo3 from 'foo';",
-          "export default function(a: (_1:Foo, _2:Foo2) => Foo3){ a; }"
-        ].join("\n"),
+        `import type Foo from 'foo';
+        import type Foo2 from 'foo';
+        import type Foo3 from 'foo';
+        export default function(a: (_1:Foo, _2:Foo2) => Foo3){ a; }`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -480,11 +450,9 @@ describe("verify", function () {
 
     it("5", function () {
       verifyAndAssertMessages(
-        [
-          "import type Foo from 'foo';",
-          "import type Foo2 from 'foo';",
-          "export default function(a: (_1:Foo, ...foo:Array<Foo2>) => number){ a; }"
-        ].join("\n"),
+        `import type Foo from 'foo';
+        import type Foo2 from 'foo';
+        export default function(a: (_1:Foo, ...foo:Array<Foo2>) => number){ a; }`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -492,10 +460,8 @@ describe("verify", function () {
 
     it("6", function () {
       verifyAndAssertMessages(
-        [
-          "import type Foo from 'foo';",
-          "export default function(): Foo {}"
-        ].join("\n"),
+        `import type Foo from 'foo';
+        export default function(): Foo {}`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -503,10 +469,8 @@ describe("verify", function () {
 
     it("7", function () {
       verifyAndAssertMessages(
-        [
-          "import type Foo from 'foo';",
-          "export default function():() => Foo {}"
-        ].join("\n"),
+        `import type Foo from 'foo';
+        export default function():() => Foo {}`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -514,11 +478,9 @@ describe("verify", function () {
 
     it("8", function () {
       verifyAndAssertMessages(
-        [
-          "import type Foo from 'foo';",
-          "import type Foo2 from 'foo';",
-          "export default function():(_?:Foo) => Foo2{}"
-        ].join("\n"),
+        `import type Foo from 'foo';
+        import type Foo2 from 'foo';
+        export default function():(_?:Foo) => Foo2{}`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -526,9 +488,7 @@ describe("verify", function () {
 
     it("9", function () {
       verifyAndAssertMessages(
-        [
-          "export default function <T1, T2>(a: T1, b: T2) { b; }"
-        ].join("\n"),
+        "export default function <T1, T2>(a: T1, b: T2) { b; }",
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -536,9 +496,7 @@ describe("verify", function () {
 
     it("10", function () {
       verifyAndAssertMessages(
-        [
-          "var a=function<T1,T2>(a: T1, b: T2) {return a + b;}; a;"
-        ].join("\n"),
+        "var a=function<T1,T2>(a: T1, b: T2) {return a + b;}; a;",
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -546,9 +504,7 @@ describe("verify", function () {
 
     it("11", function () {
       verifyAndAssertMessages(
-        [
-          "var a={*id<T>(x: T): T { x; }}; a;"
-        ].join("\n"),
+        "var a={*id<T>(x: T): T { x; }}; a;",
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -556,9 +512,7 @@ describe("verify", function () {
 
     it("12", function () {
       verifyAndAssertMessages(
-        [
-          "var a={async id<T>(x: T): T { x; }}; a;"
-        ].join("\n"),
+        "var a={async id<T>(x: T): T { x; }}; a;",
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -566,9 +520,7 @@ describe("verify", function () {
 
     it("13", function () {
       verifyAndAssertMessages(
-        [
-          "var a={123<T>(x: T): T { x; }}; a;"
-        ].join("\n"),
+        "var a={123<T>(x: T): T { x; }}; a;",
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -576,11 +528,9 @@ describe("verify", function () {
 
     it("14", function () {
       verifyAndAssertMessages(
-        [
-          "import type Foo from 'foo';",
-          "import type Foo2 from 'foo';",
-          "export default class Bar {set fooProp(value:Foo):Foo2{ value; }}"
-        ].join("\n"),
+        `import type Foo from 'foo';
+        import type Foo2 from 'foo';
+        export default class Bar {set fooProp(value:Foo):Foo2{ value; }}`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -588,10 +538,8 @@ describe("verify", function () {
 
     it("15", function () {
       verifyAndAssertMessages(
-        [
-          "import type Foo2 from 'foo';",
-          "export default class Foo {get fooProp(): Foo2{}}"
-        ].join("\n"),
+        `import type Foo2 from 'foo';
+        export default class Foo {get fooProp(): Foo2{}}`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -599,10 +547,8 @@ describe("verify", function () {
 
     it("16", function () {
       verifyAndAssertMessages(
-        [
-          "import type Foo from 'foo';",
-          "var numVal:Foo; numVal;"
-        ].join("\n"),
+        `import type Foo from 'foo';
+        var numVal:Foo; numVal;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -610,10 +556,8 @@ describe("verify", function () {
 
     it("17", function () {
       verifyAndAssertMessages(
-        [
-          "import type Foo from 'foo';",
-          "var a: {numVal: Foo;}; a;"
-        ].join("\n"),
+        `import type Foo from 'foo';
+        var a: {numVal: Foo;}; a;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -621,12 +565,10 @@ describe("verify", function () {
 
     it("18", function () {
       verifyAndAssertMessages(
-        [
-          "import type Foo from 'foo';",
-          "import type Foo2 from 'foo';",
-          "import type Foo3 from 'foo';",
-          "var a: ?{numVal: Foo; [indexer: Foo2]: Foo3}; a;"
-        ].join("\n"),
+        `import type Foo from 'foo';
+        import type Foo2 from 'foo';
+        import type Foo3 from 'foo';
+        var a: ?{numVal: Foo; [indexer: Foo2]: Foo3}; a;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -634,11 +576,9 @@ describe("verify", function () {
 
     it("19", function () {
       verifyAndAssertMessages(
-        [
-          "import type Foo from 'foo';",
-          "import type Foo2 from 'foo';",
-          "var a: {numVal: Foo; subObj?: ?{strVal: Foo2}}; a;"
-        ].join("\n"),
+        `import type Foo from 'foo';
+        import type Foo2 from 'foo';
+        var a: {numVal: Foo; subObj?: ?{strVal: Foo2}}; a;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -646,13 +586,11 @@ describe("verify", function () {
 
     it("20", function () {
       verifyAndAssertMessages(
-        [
-          "import type Foo from 'foo';",
-          "import type Foo2 from 'foo';",
-          "import type Foo3 from 'foo';",
-          "import type Foo4 from 'foo';",
-          "var a: { [a: Foo]: Foo2; [b: Foo3]: Foo4; }; a;"
-        ].join("\n"),
+        `import type Foo from 'foo';
+        import type Foo2 from 'foo';
+        import type Foo3 from 'foo';
+        import type Foo4 from 'foo';
+        var a: { [a: Foo]: Foo2; [b: Foo3]: Foo4; }; a;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -660,12 +598,10 @@ describe("verify", function () {
 
     it("21", function () {
       verifyAndAssertMessages(
-        [
-          "import type Foo from 'foo';",
-          "import type Foo2 from 'foo';",
-          "import type Foo3 from 'foo';",
-          "var a: {add(x:Foo, ...y:Array<Foo2>): Foo3}; a;"
-        ].join("\n"),
+        `import type Foo from 'foo';
+        import type Foo2 from 'foo';
+        import type Foo3 from 'foo';
+        var a: {add(x:Foo, ...y:Array<Foo2>): Foo3}; a;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -673,12 +609,10 @@ describe("verify", function () {
 
     it("22", function () {
       verifyAndAssertMessages(
-        [
-          "import type Foo from 'foo';",
-          "import type Foo2 from 'foo';",
-          "import type Foo3 from 'foo';",
-          "var a: { id<Foo>(x: Foo2): Foo3; }; a;"
-        ].join("\n"),
+        `import type Foo from 'foo';
+        import type Foo2 from 'foo';
+        import type Foo3 from 'foo';
+        var a: { id<Foo>(x: Foo2): Foo3; }; a;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -686,10 +620,8 @@ describe("verify", function () {
 
     it("23", function () {
       verifyAndAssertMessages(
-        [
-          "import type Foo from 'foo';",
-          "var a:Array<Foo> = [1, 2, 3]; a;"
-        ].join("\n"),
+        `import type Foo from 'foo';
+        var a:Array<Foo> = [1, 2, 3]; a;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -697,10 +629,8 @@ describe("verify", function () {
 
     it("24", function () {
       verifyAndAssertMessages(
-        [
-          "import type Baz from 'baz';",
-          "export default class Bar<T> extends Baz<T> { };"
-        ].join("\n"),
+        `import type Baz from 'baz';
+        export default class Bar<T> extends Baz<T> { };`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -708,9 +638,7 @@ describe("verify", function () {
 
     it("25", function () {
       verifyAndAssertMessages(
-        [
-          "export default class Bar<T> { bar(): T { return 42; }}"
-        ].join("\n"),
+        "export default class Bar<T> { bar(): T { return 42; }}",
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -718,11 +646,9 @@ describe("verify", function () {
 
     it("26", function () {
       verifyAndAssertMessages(
-        [
-          "import type Foo from 'foo';",
-          "import type Foo2 from 'foo';",
-          "export default class Bar { static prop1:Foo; prop2:Foo2; }"
-        ].join("\n"),
+        `import type Foo from 'foo';
+        import type Foo2 from 'foo';
+        export default class Bar { static prop1:Foo; prop2:Foo2; }`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -730,11 +656,9 @@ describe("verify", function () {
 
     it("27", function () {
       verifyAndAssertMessages(
-        [
-          "import type Foo from 'foo';",
-          "import type Foo2 from 'foo';",
-          "var x : Foo | Foo2 = 4; x;"
-        ].join("\n"),
+        `import type Foo from 'foo';
+        import type Foo2 from 'foo';
+        var x : Foo | Foo2 = 4; x;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -742,11 +666,9 @@ describe("verify", function () {
 
     it("28", function () {
       verifyAndAssertMessages(
-        [
-          "import type Foo from 'foo';",
-          "import type Foo2 from 'foo';",
-          "var x : () => Foo | () => Foo2; x;"
-        ].join("\n"),
+        `import type Foo from 'foo';
+        import type Foo2 from 'foo';
+        var x : () => Foo | () => Foo2; x;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -754,11 +676,9 @@ describe("verify", function () {
 
     it("29", function () {
       verifyAndAssertMessages(
-        [
-          "import type Foo from 'foo';",
-          "import type Foo2 from 'foo';",
-          "var x: typeof Foo | number = Foo2; x;"
-        ].join("\n"),
+        `import type Foo from 'foo';
+        import type Foo2 from 'foo';
+        var x: typeof Foo | number = Foo2; x;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -766,10 +686,8 @@ describe("verify", function () {
 
     it("30", function () {
       verifyAndAssertMessages(
-        [
-          "import type Foo from 'foo';",
-          "var {x}: {x: Foo; } = { x: 'hello' }; x;"
-        ].join("\n"),
+        `import type Foo from 'foo';
+        var {x}: {x: Foo; } = { x: 'hello' }; x;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -777,10 +695,8 @@ describe("verify", function () {
 
     it("31", function () {
       verifyAndAssertMessages(
-        [
-          "import type Foo from 'foo';",
-          "var [x]: Array<Foo> = [ 'hello' ]; x;"
-        ].join("\n"),
+        `import type Foo from 'foo';
+        var [x]: Array<Foo> = [ 'hello' ]; x;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -788,10 +704,8 @@ describe("verify", function () {
 
     it("32", function () {
       verifyAndAssertMessages(
-        [
-          "import type Foo from 'foo';",
-          "export default function({x}: { x: Foo; }) { x; }"
-        ].join("\n"),
+        `import type Foo from 'foo';
+        export default function({x}: { x: Foo; }) { x; }`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -799,10 +713,8 @@ describe("verify", function () {
 
     it("33", function () {
       verifyAndAssertMessages(
-        [
-          "import type Foo from 'foo';",
-          "function foo([x]: Array<Foo>) { x; } foo();"
-        ].join("\n"),
+        `import type Foo from 'foo';
+        function foo([x]: Array<Foo>) { x; } foo();`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -810,11 +722,9 @@ describe("verify", function () {
 
     it("34", function () {
       verifyAndAssertMessages(
-        [
-          "import type Foo from 'foo';",
-          "import type Foo2 from 'foo';",
-          "var a: Map<Foo, Array<Foo2> >; a;"
-        ].join("\n"),
+        `import type Foo from 'foo';
+        import type Foo2 from 'foo';
+        var a: Map<Foo, Array<Foo2> >; a;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -822,10 +732,8 @@ describe("verify", function () {
 
     it("35", function () {
       verifyAndAssertMessages(
-        [
-          "import type Foo from 'foo';",
-          "var a: ?Promise<Foo>[]; a;"
-        ].join("\n"),
+        `import type Foo from 'foo';
+        var a: ?Promise<Foo>[]; a;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -833,11 +741,9 @@ describe("verify", function () {
 
     it("36", function () {
       verifyAndAssertMessages(
-        [
-          "import type Foo from 'foo';",
-          "import type Foo2 from 'foo';",
-          "var a:(...rest:Array<Foo>) => Foo2; a;"
-        ].join("\n"),
+        `import type Foo from 'foo';
+        import type Foo2 from 'foo';
+        var a:(...rest:Array<Foo>) => Foo2; a;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -845,13 +751,11 @@ describe("verify", function () {
 
     it("37", function () {
       verifyAndAssertMessages(
-        [
-          "import type Foo from 'foo';",
-          "import type Foo2 from 'foo';",
-          "import type Foo3 from 'foo';",
-          "import type Foo4 from 'foo';",
-          "var a: <Foo>(x: Foo2, ...y:Foo3[]) => Foo4; a;"
-        ].join("\n"),
+        `import type Foo from 'foo';
+        import type Foo2 from 'foo';
+        import type Foo3 from 'foo';
+        import type Foo4 from 'foo';
+        var a: <Foo>(x: Foo2, ...y:Foo3[]) => Foo4; a;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -859,10 +763,8 @@ describe("verify", function () {
 
     it("38", function () {
       verifyAndAssertMessages(
-        [
-          "import type {foo, bar} from 'baz';",
-          "foo; bar;"
-        ].join("\n"),
+        `import type {foo, bar} from 'baz';
+        foo; bar;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -870,10 +772,8 @@ describe("verify", function () {
 
     it("39", function () {
       verifyAndAssertMessages(
-        [
-          "import type {foo as bar} from 'baz';",
-          "bar;"
-        ].join("\n"),
+        `import type {foo as bar} from 'baz';
+        bar;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -881,10 +781,8 @@ describe("verify", function () {
 
     it("40", function () {
       verifyAndAssertMessages(
-        [
-          "import type from 'foo';",
-          "type;"
-        ].join("\n"),
+        `import type from 'foo';
+        type;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -892,10 +790,8 @@ describe("verify", function () {
 
     it("41", function () {
       verifyAndAssertMessages(
-        [
-          "import type, {foo} from 'bar';",
-          "type; foo;"
-        ].join("\n"),
+        `import type, {foo} from 'bar';
+        type; foo;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -903,10 +799,8 @@ describe("verify", function () {
 
     it("42", function () {
       verifyAndAssertMessages(
-        [
-          "import type * as namespace from 'bar';",
-          "namespace;"
-        ].join("\n"),
+        `import type * as namespace from 'bar';
+        namespace;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -914,10 +808,8 @@ describe("verify", function () {
 
     it("43", function () {
       verifyAndAssertMessages(
-        [
-          "import type Foo from 'foo';",
-          "var a: Foo[]; a;"
-        ].join("\n"),
+        `import type Foo from 'foo';
+        var a: Foo[]; a;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -925,10 +817,8 @@ describe("verify", function () {
 
     it("44", function () {
       verifyAndAssertMessages(
-        [
-          "import type Foo from 'foo';",
-          "var a: ?Foo[]; a;"
-        ].join("\n"),
+        `import type Foo from 'foo';
+        var a: ?Foo[]; a;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -936,10 +826,8 @@ describe("verify", function () {
 
     it("45", function () {
       verifyAndAssertMessages(
-        [
-          "import type Foo from 'foo';",
-          "var a: (?Foo)[]; a;"
-        ].join("\n"),
+        `import type Foo from 'foo';
+        var a: (?Foo)[]; a;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -947,10 +835,8 @@ describe("verify", function () {
 
     it("46", function () {
       verifyAndAssertMessages(
-        [
-          "import type Foo from 'foo';",
-          "var a: () => Foo[]; a;"
-        ].join("\n"),
+        `import type Foo from 'foo';
+        var a: () => Foo[]; a;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -958,10 +844,8 @@ describe("verify", function () {
 
     it("47", function () {
       verifyAndAssertMessages(
-        [
-          "import type Foo from 'foo';",
-          "var a: (() => Foo)[]; a;"
-        ].join("\n"),
+        `import type Foo from 'foo';
+        var a: (() => Foo)[]; a;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -969,10 +853,8 @@ describe("verify", function () {
 
     it("48", function () {
       verifyAndAssertMessages(
-        [
-          "import type Foo from 'foo';",
-          "var a: typeof Foo[]; a;"
-        ].join("\n"),
+        `import type Foo from 'foo';
+        var a: typeof Foo[]; a;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -980,12 +862,10 @@ describe("verify", function () {
 
     it("49", function () {
       verifyAndAssertMessages(
-        [
-          "import type Foo from 'foo';",
-          "import type Foo2 from 'foo';",
-          "import type Foo3 from 'foo';",
-          "var a : [Foo, Foo2<Foo3>,] = [123, 'duck',]; a;"
-        ].join("\n"),
+        `import type Foo from 'foo';
+        import type Foo2 from 'foo';
+        import type Foo3 from 'foo';
+        var a : [Foo, Foo2<Foo3>,] = [123, 'duck',]; a;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
       );
@@ -1001,13 +881,12 @@ describe("verify", function () {
   });
 
   it("class definition: gaearon/redux#24", function () {
-    verifyAndAssertMessages([
-      "export default function root(stores) {",
-      "return DecoratedComponent => class ReduxRootDecorator {",
-      "a() { DecoratedComponent; stores; }",
-      "};",
-      "}",
-    ].join("\n"),
+    verifyAndAssertMessages(
+      `export default function root(stores) {
+      return DecoratedComponent => class ReduxRootDecorator {
+      a() { DecoratedComponent; stores; }
+      };
+      }`,
       { "no-undef": 1, "no-unused-vars": 1 },
       []
     );
@@ -1030,13 +909,13 @@ describe("verify", function () {
   });
 
   it("template with destructuring #31", function () {
-    verifyAndAssertMessages([
-      "module.exports = {",
-      "render() {",
-      "var {name} = this.props;",
-      "return Math.max(null, `Name: ${name}, Name: ${name}`);",
-      "}",
-      "};"].join("\n"),
+    verifyAndAssertMessages(
+      `module.exports = {
+      render() {
+      var {name} = this.props;
+      return Math.max(null, \`Name: \${name}, Name: \${name}\`);
+      }
+      };`,
       { "comma-spacing": 1 },
       []
     );
@@ -1045,14 +924,12 @@ describe("verify", function () {
   describe("decorators #72", function () {
     it("class declaration", function () {
       verifyAndAssertMessages(
-        [
-          "import classDeclaration from 'decorator';",
-          "import decoratorParameter from 'decorator';",
-          "@classDeclaration((parameter) => parameter)",
-          "@classDeclaration(decoratorParameter)",
-          "@classDeclaration",
-          "export class TextareaAutosize {}"
-        ].join("\n"),
+        `import classDeclaration from 'decorator';
+        import decoratorParameter from 'decorator';
+        @classDeclaration((parameter) => parameter)
+        @classDeclaration(decoratorParameter)
+        @classDeclaration
+        export class TextareaAutosize {}`,
         { "no-unused-vars": 1 },
         []
       );
@@ -1060,18 +937,16 @@ describe("verify", function () {
 
     it("method definition", function () {
       verifyAndAssertMessages(
-        [
-          "import classMethodDeclarationA from 'decorator';",
-          "import decoratorParameter from 'decorator';",
-          "export class TextareaAutosize {",
-          "@classMethodDeclarationA((parameter) => parameter)",
-          "@classMethodDeclarationA(decoratorParameter)",
-          "@classMethodDeclarationA",
-          "methodDeclaration(e) {",
-          "e();",
-          "}",
-          "}"
-        ].join("\n"),
+        `import classMethodDeclarationA from 'decorator';
+        import decoratorParameter from 'decorator';
+        export class TextareaAutosize {
+        @classMethodDeclarationA((parameter) => parameter)
+        @classMethodDeclarationA(decoratorParameter)
+        @classMethodDeclarationA
+        methodDeclaration(e) {
+        e();
+        }
+        }`,
         { "no-unused-vars": 1 },
         []
       );
@@ -1079,20 +954,18 @@ describe("verify", function () {
 
     it("method definition get/set", function () {
       verifyAndAssertMessages(
-        [
-          "import classMethodDeclarationA from 'decorator';",
-          "import decoratorParameter from 'decorator';",
-          "export class TextareaAutosize {",
-          "@classMethodDeclarationA((parameter) => parameter)",
-          "@classMethodDeclarationA(decoratorParameter)",
-          "@classMethodDeclarationA",
-          "get bar() { }",
-          "@classMethodDeclarationA((parameter) => parameter)",
-          "@classMethodDeclarationA(decoratorParameter)",
-          "@classMethodDeclarationA",
-          "set bar(val) { val; }",
-          "}"
-        ].join("\n"),
+        `import classMethodDeclarationA from 'decorator';
+        import decoratorParameter from 'decorator';
+        export class TextareaAutosize {
+        @classMethodDeclarationA((parameter) => parameter)
+        @classMethodDeclarationA(decoratorParameter)
+        @classMethodDeclarationA
+        get bar() { }
+        @classMethodDeclarationA((parameter) => parameter)
+        @classMethodDeclarationA(decoratorParameter)
+        @classMethodDeclarationA
+        set bar(val) { val; }
+        }`,
         { "no-unused-vars": 1 },
         []
       );
@@ -1100,19 +973,17 @@ describe("verify", function () {
 
     it("object property", function () {
       verifyAndAssertMessages(
-        [
-          "import classMethodDeclarationA from 'decorator';",
-          "import decoratorParameter from 'decorator';",
-          "var obj = {",
-          "@classMethodDeclarationA((parameter) => parameter)",
-          "@classMethodDeclarationA(decoratorParameter)",
-          "@classMethodDeclarationA",
-          "methodDeclaration(e) {",
-          "e();",
-          "}",
-          "};",
-          "obj;"
-        ].join("\n"),
+        `import classMethodDeclarationA from 'decorator';
+        import decoratorParameter from 'decorator';
+        var obj = {
+        @classMethodDeclarationA((parameter) => parameter)
+        @classMethodDeclarationA(decoratorParameter)
+        @classMethodDeclarationA
+        methodDeclaration(e) {
+        e();
+        }
+        };
+        obj;`,
         { "no-unused-vars": 1 },
         []
       );
@@ -1120,21 +991,19 @@ describe("verify", function () {
 
     it("object property get/set", function () {
       verifyAndAssertMessages(
-        [
-          "import classMethodDeclarationA from 'decorator';",
-          "import decoratorParameter from 'decorator';",
-          "var obj = {",
-          "@classMethodDeclarationA((parameter) => parameter)",
-          "@classMethodDeclarationA(decoratorParameter)",
-          "@classMethodDeclarationA",
-          "get bar() { },",
-          "@classMethodDeclarationA((parameter) => parameter)",
-          "@classMethodDeclarationA(decoratorParameter)",
-          "@classMethodDeclarationA",
-          "set bar(val) { val; }",
-          "};",
-          "obj;"
-        ].join("\n"),
+        `import classMethodDeclarationA from 'decorator';
+        import decoratorParameter from 'decorator';
+        var obj = {
+        @classMethodDeclarationA((parameter) => parameter)
+        @classMethodDeclarationA(decoratorParameter)
+        @classMethodDeclarationA
+        get bar() { },
+        @classMethodDeclarationA((parameter) => parameter)
+        @classMethodDeclarationA(decoratorParameter)
+        @classMethodDeclarationA
+        set bar(val) { val; }
+        };
+        obj;`,
         { "no-unused-vars": 1 },
         []
       );
@@ -1201,14 +1070,13 @@ describe("verify", function () {
   });
 
   it("don't warn no-unused-vars with spread #142", function () {
-    verifyAndAssertMessages([
-      "export default function test(data) {",
-      "return {",
-      "foo: 'bar',",
-      "...data",
-      "};",
-      "}",
-    ].join("\n"),
+    verifyAndAssertMessages(
+      `export default function test(data) {
+      return {
+      foo: 'bar',
+      ...data
+      };
+      }`,
       { "no-undef": 1, "no-unused-vars": 1 },
       []
     );
@@ -1216,33 +1084,28 @@ describe("verify", function () {
 
   it("excludes comment tokens #153", function () {
     verifyAndAssertMessages(
-      [
-        "var a = [",
-        "1,",
-        "2, // a trailing comment makes this line fail comma-dangle (always-multiline)",
-        "];",
-      ].join("\n"),
+      `var a = [
+      1,
+      2, // a trailing comment makes this line fail comma-dangle (always-multiline)
+      ];`,
       { "comma-dangle": [2, "always-multiline"] },
       []
     );
 
     verifyAndAssertMessages(
-      [
-        "switch (a) {",
-        "// A comment here makes the above line fail brace-style",
-        "case 1:",
-        "console.log(a);",
-        "}"
-      ].join("\n"),
+      `switch (a) {
+      // A comment here makes the above line fail brace-style
+      case 1:
+      console.log(a);
+      }`,
       { "brace-style": 2 },
       []
     );
   });
 
   it("ternary and parens #149", function () {
-    verifyAndAssertMessages([
-      "true ? (true) : false;"
-    ].join("\n"),
+    verifyAndAssertMessages(
+    "true ? (true) : false;",
       { "space-infix-ops": 1 },
       []
     );
@@ -1250,15 +1113,13 @@ describe("verify", function () {
 
   it("line comment space-in-parens #124", function () {
     verifyAndAssertMessages(
-      [
-        "React.createClass({",
-        "render() {",
-        "// return (",
-        "//   <div />",
-        "// ); // <-- this is the line that is reported",
-        "}",
-        "});"
-      ].join("\n"),
+      `React.createClass({
+      render() {
+      // return (
+      //   <div />
+      // ); // <-- this is the line that is reported
+      }
+      });`,
       { "space-in-parens": 1 },
       [ ]
     );
@@ -1266,17 +1127,15 @@ describe("verify", function () {
 
   it("block comment space-in-parens #124", function () {
     verifyAndAssertMessages(
-      [
-        "React.createClass({",
-        "render() {",
-        "/*",
-        "return (",
-        "  <div />",
-        "); // <-- this is the line that is reported",
-        "*/",
-        "}",
-        "});"
-      ].join("\n"),
+      `React.createClass({
+      render() {
+      /*
+      return (
+        <div />
+      ); // <-- this is the line that is reported
+      */
+      }
+      });`,
       { "space-in-parens": 1 },
       [ ]
     );
@@ -1298,18 +1157,16 @@ describe("verify", function () {
 
   it("default param flow type no-unused-vars #184", function () {
     verifyAndAssertMessages(
-      [
-        "type ResolveOptionType = {",
-        "depth?: number,",
-        "identifier?: string",
-        "};",
-        "",
-        "export default function resolve(",
-        "options: ResolveOptionType = {}",
-        "): Object {",
-        "options;",
-        "}",
-      ].join("\n"),
+      `type ResolveOptionType = {
+      depth?: number,
+      identifier?: string
+      };
+
+      export default function resolve(
+      options: ResolveOptionType = {}
+      ): Object {
+      options;
+      }`,
       { "no-unused-vars": 1, "no-undef": 1 },
       [ ]
     );
@@ -1317,10 +1174,8 @@ describe("verify", function () {
 
   it("no-use-before-define #192", function () {
     verifyAndAssertMessages(
-      [
-        "console.log(x);",
-        "var x = 1;"
-      ].join("\n"),
+      `console.log(x);
+      var x = 1;`,
       { "no-use-before-define": 1 },
       [ "1:13 'x' was used before it was defined. no-use-before-define" ]
     );
@@ -1335,50 +1190,46 @@ describe("verify", function () {
   });
 
   it("getter/setter #218", function () {
-    verifyAndAssertMessages([
-      "class Person {",
-      "    set a (v) { }",
-      "}"
-    ].join("\n"),
+    verifyAndAssertMessages(
+      `class Person {
+          set a (v) { }
+      }`,
       { "space-before-function-paren": 1, "keyword-spacing": [1, {"before": true}], "indent": 1 },
       []
     );
   });
 
   it("getter/setter #220", function () {
-    verifyAndAssertMessages([
-      "var B = {",
-      "get x () {",
-      "return this.ecks;",
-      "},",
-      "set x (ecks) {",
-      "this.ecks = ecks;",
-      "}",
-      "};"
-    ].join("\n"),
+    verifyAndAssertMessages(
+      `var B = {
+      get x () {
+      return this.ecks;
+      },
+      set x (ecks) {
+      this.ecks = ecks;
+      }
+      };`,
       { "no-dupe-keys": 1 },
       []
     );
   });
 
   it("fixes issues with flow types and ObjectPattern", function () {
-    verifyAndAssertMessages([
-      "import type Foo from 'bar';",
-      "export default class Foobar {",
-      "  foo({ bar }: Foo) { bar; }",
-      "  bar({ foo }: Foo) { foo; }",
-      "}"
-    ].join("\n"),
+    verifyAndAssertMessages(
+      `import type Foo from 'bar';
+      export default class Foobar {
+        foo({ bar }: Foo) { bar; }
+        bar({ foo }: Foo) { foo; }
+      }`,
       { "no-unused-vars": 1, "no-shadow": 1 },
       []
     );
   });
 
   it("correctly detects redeclares if in script mode #217", function () {
-    verifyAndAssertMessages([
-      "var a = 321;",
-      "var a = 123;",
-    ].join("\n"),
+    verifyAndAssertMessages(
+      `var a = 321;
+      var a = 123;`,
       { "no-redeclare": 1 },
       [ "2:5 'a' is already defined. no-redeclare" ],
       "script"
@@ -1386,10 +1237,9 @@ describe("verify", function () {
   });
 
   it("correctly detects redeclares if in module mode #217", function () {
-    verifyAndAssertMessages([
-      "var a = 321;",
-      "var a = 123;",
-    ].join("\n"),
+    verifyAndAssertMessages(
+      `var a = 321;
+      var a = 123;`,
       { "no-redeclare": 1 },
       [ "2:5 'a' is already defined. no-redeclare" ],
       "module"
@@ -1436,11 +1286,10 @@ describe("verify", function () {
   });
 
   it("allowImportExportEverywhere option (#327)", function () {
-    verifyAndAssertMessages([
-      "if (true) { import Foo from 'foo'; }",
-      "function foo() { import Bar from 'bar'; }",
-      "switch (a) { case 1: import FooBar from 'foobar'; }"
-    ].join("\n"),
+    verifyAndAssertMessages(
+      `if (true) { import Foo from 'foo'; }
+      function foo() { import Bar from 'bar'; }
+      switch (a) { case 1: import FooBar from 'foobar'; }`,
       {},
       [],
       "module",
@@ -1477,49 +1326,45 @@ describe("verify", function () {
   });
 
   it("decorator does not create TypeError #229", function () {
-    verifyAndAssertMessages([
-      "class A {",
-      "  @test",
-      "  f() {}",
-      "}"
-    ].join("\n"),
+    verifyAndAssertMessages(
+      `class A {
+        @test
+        f() {}
+      }`,
       { "no-undef": 1 },
       [ "2:4 'test' is not defined. no-undef" ]
     );
   });
 
   it("Flow definition does not trigger warnings #223", function () {
-    verifyAndAssertMessages([
-      "import { Map as $Map } from 'immutable';",
-      "function myFunction($state: $Map, { a, b, c } : { a: ?Object, b: ?Object, c: $Map }) {}"
-    ].join("\n"),
+    verifyAndAssertMessages(
+      `import { Map as $Map } from 'immutable';
+      function myFunction($state: $Map, { a, b, c } : { a: ?Object, b: ?Object, c: $Map }) {}`,
       { "no-dupe-args": 1, "no-redeclare": 1, "no-shadow": 1 },
       []
     );
   });
 
   it("newline-before-return with comments #289", function () {
-    verifyAndAssertMessages([
-      "function a() {",
-      "if (b) {",
-      "/* eslint-disable no-console */",
-      "console.log('test');",
-      "/* eslint-enable no-console */",
-      "}",
-      "",
-      "return hasGlobal;",
-      "}"
-    ].join("\n"),
+    verifyAndAssertMessages(
+      `function a() {
+      if (b) {
+      /* eslint-disable no-console */
+      console.log('test');
+      /* eslint-enable no-console */
+      }
+
+      return hasGlobal;
+      }`,
       { "newline-before-return": 1 },
       []
     );
   });
 
   it("spaced-comment with shebang #163", function () {
-    verifyAndAssertMessages(["#!/usr/bin/env babel-node",
-        "",
-        "import {spawn} from 'foobar';"
-      ].join("\n"),
+    verifyAndAssertMessages(
+      `#!/usr/bin/env babel-node
+      import {spawn} from 'foobar';`,
       { "spaced-comment": 1 },
       []
     );
@@ -1528,14 +1373,12 @@ describe("verify", function () {
   describe("Class Property Declarations", function() {
     it("no-redeclare false positive 1", function() {
       verifyAndAssertMessages(
-        [
-          "class Group {",
-          "  static propTypes = {};",
-          "}",
-          "class TypicalForm {",
-          "  static propTypes = {};",
-          "}"
-        ].join("\n"),
+        `class Group {
+          static propTypes = {};
+        }
+        class TypicalForm {
+          static propTypes = {};
+        }`,
         { "no-redeclare": 1 },
         []
       );
@@ -1543,12 +1386,10 @@ describe("verify", function () {
 
     it("no-redeclare false positive 2", function() {
       verifyAndAssertMessages(
-        [
-          "function validate() {}",
-          "class MyComponent {",
-          "  static validate = validate;",
-          "}"
-        ].join("\n"),
+        `function validate() {}
+        class MyComponent {
+          static validate = validate;
+        }`,
         { "no-redeclare": 1 },
         []
       );
@@ -1556,15 +1397,13 @@ describe("verify", function () {
 
     it("check references", function() {
       verifyAndAssertMessages(
-        [
-          "var a;",
-          "class A {",
-          "  prop1;",
-          "  prop2 = a;",
-          "  prop3 = b;",
-          "}",
-          "new A"
-        ].join("\n"),
+        `var a;
+        class A {
+          prop1;
+          prop2 = a;
+          prop3 = b;
+        }
+        new A`,
         { "no-undef": 1, "no-unused-vars": 1, "no-redeclare": 1 },
         [
           "5:11 'b' is not defined. no-undef"

--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -67,8 +67,8 @@ describe("verify", function () {
   });
 
   it("Modules support (issue #5)", function () {
-    verifyAndAssertMessages(
-      `import Foo from 'foo';
+    verifyAndAssertMessages(`
+      import Foo from 'foo';
       export default Foo;
       export const c = 'c';
       export class Store {}`,
@@ -160,8 +160,8 @@ describe("verify", function () {
   });
 
   it("comment with padded-blocks (issue #33)", function () {
-    verifyAndAssertMessages(
-      `if (a) {
+    verifyAndAssertMessages(`
+      if (a) {
         // i'm a comment!
         let b = c
       }`,
@@ -196,8 +196,8 @@ describe("verify", function () {
     });
 
     it("multiple nullable type annotations and return #108", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         import type Foo2 from 'foo';
         import type Foo3 from 'foo';
         function log(foo: ?Foo, foo2: ?Foo2): ?Foo3 {
@@ -210,8 +210,8 @@ describe("verify", function () {
     });
 
     it("type parameters", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         import type Foo2 from 'foo';
         function log<T1, T2>(a: T1, b: T2) { return a + b; }
         log<Foo, Foo2>(1, 2);`,
@@ -221,8 +221,8 @@ describe("verify", function () {
     });
 
     it("nested type annotations", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         function foo(callback: () => Foo) {
           return callback();
         }
@@ -233,8 +233,8 @@ describe("verify", function () {
     });
 
     it("type in var declaration", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         var x: Foo = 1;
         x;`,
         { "no-unused-vars": 1, "no-undef": 1 },
@@ -243,8 +243,8 @@ describe("verify", function () {
     });
 
     it("object type annotation", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         var a: {numVal: Foo};
         a;`,
         { "no-unused-vars": 1, "no-undef": 1 },
@@ -253,8 +253,8 @@ describe("verify", function () {
     });
 
     it("object property types", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         import type Foo2 from 'foo';
         var a = {
           circle: (null : ?{ setNativeProps(props: Foo): Foo2 })
@@ -266,8 +266,8 @@ describe("verify", function () {
     });
 
     it("namespaced types", function () {
-      verifyAndAssertMessages(
-        `var React = require('react-native');
+      verifyAndAssertMessages(`
+        var React = require('react-native');
         var b = {
           openExternalExample: (null: ?React.Component)
         };
@@ -282,8 +282,8 @@ describe("verify", function () {
     });
 
     it("ArrayTypeAnnotation", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         var x: Foo[]; x;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
@@ -291,8 +291,8 @@ describe("verify", function () {
     });
 
     it("ClassImplements", function () {
-      verifyAndAssertMessages(
-        `import type Bar from 'foo';
+      verifyAndAssertMessages(`
+        import type Bar from 'foo';
         export default class Foo implements Bar {}`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
@@ -300,8 +300,8 @@ describe("verify", function () {
     });
 
     it("type alias creates declaration + usage", function () {
-      verifyAndAssertMessages(
-        `type Foo = any;
+      verifyAndAssertMessages(`
+        type Foo = any;
         var x : Foo = 1; x;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
@@ -309,8 +309,8 @@ describe("verify", function () {
     });
 
     it("type alias with type parameters", function () {
-      verifyAndAssertMessages(
-        `import type Bar from 'foo';
+      verifyAndAssertMessages(`
+        import type Bar from 'foo';
         import type Foo3 from 'foo';
         type Foo<T> = Bar<T, Foo3>
         var x : Foo = 1; x;`,
@@ -320,8 +320,8 @@ describe("verify", function () {
     });
 
     it("export type alias", function () {
-      verifyAndAssertMessages(
-        `import type Foo2 from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo2 from 'foo';
         export type Foo = Foo2;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
@@ -337,8 +337,8 @@ describe("verify", function () {
     });
 
     it("types definition from import", function () {
-      verifyAndAssertMessages(
-        `import type Promise from 'bluebird';
+      verifyAndAssertMessages(`
+        import type Promise from 'bluebird';
         type Operation = () => Promise;
         x: Operation;`,
         { "no-unused-vars": 1, "no-undef": 1 },
@@ -347,8 +347,8 @@ describe("verify", function () {
     });
 
     it("polymorphpic/generic types for class #123", function () {
-      verifyAndAssertMessages(
-        `class Box<T> {
+      verifyAndAssertMessages(`
+        class Box<T> {
           value: T;
         }
         var box = new Box();
@@ -359,8 +359,8 @@ describe("verify", function () {
     });
 
     it("polymorphpic/generic types for function #123", function () {
-      verifyAndAssertMessages(
-        `export function identity<T>(value) {
+      verifyAndAssertMessages(`
+        export function identity<T>(value) {
           var a: T = value; a;
         }`,
         { "no-unused-vars": 1, "no-undef": 1 },
@@ -369,8 +369,8 @@ describe("verify", function () {
     });
 
     it("polymorphpic/generic types for type alias #123", function () {
-      verifyAndAssertMessages(
-        `import Bar from './Bar';
+      verifyAndAssertMessages(`
+        import Bar from './Bar';
         type Foo<T> = Bar<T>; var x: Foo = 1; console.log(x);`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
@@ -378,27 +378,27 @@ describe("verify", function () {
     });
 
     it("polymorphpic/generic types - outside of fn scope #123", function () {
-      verifyAndAssertMessages(
-        `export function foo<T>(value) { value; };
+      verifyAndAssertMessages(`
+        export function foo<T>(value) { value; };
         var b: T = 1; b;`,
         { "no-unused-vars": 1, "no-undef": 1 },
-        [ "1:21 'T' is defined but never used. no-unused-vars",
-          "2:16 'T' is not defined. no-undef" ]
+        [ "2:29 'T' is defined but never used. no-unused-vars",
+          "3:16 'T' is not defined. no-undef" ]
       );
     });
 
     it("polymorphpic/generic types - extending unknown #123", function () {
-      verifyAndAssertMessages(
-        `import Bar from 'bar';
+      verifyAndAssertMessages(`
+        import Bar from 'bar';
         export class Foo extends Bar<T> {}`,
         { "no-unused-vars": 1, "no-undef": 1 },
-        [ "2:38 'T' is not defined. no-undef" ]
+        [ "3:38 'T' is not defined. no-undef" ]
       );
     });
 
     it("support declarations #132", function () {
-      verifyAndAssertMessages(
-        `declare class A { static () : number }
+      verifyAndAssertMessages(`
+        declare class A { static () : number }
         declare module B { declare var x: number; }
         declare function foo<T>(): void;
         declare var bar
@@ -409,8 +409,8 @@ describe("verify", function () {
     });
 
     it("1", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         import type Foo2 from 'foo';
         export default function(a: Foo, b: ?Foo2, c){ a; b; c; }`,
         { "no-unused-vars": 1, "no-undef": 1 },
@@ -419,8 +419,8 @@ describe("verify", function () {
     });
 
     it("2", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         export default function(a: () => Foo){ a; }`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
@@ -428,8 +428,8 @@ describe("verify", function () {
     });
 
     it("3", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         import type Foo2 from 'foo';
         export default function(a: (_:Foo) => Foo2){ a; }`,
         { "no-unused-vars": 1, "no-undef": 1 },
@@ -438,8 +438,8 @@ describe("verify", function () {
     });
 
     it("4", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         import type Foo2 from 'foo';
         import type Foo3 from 'foo';
         export default function(a: (_1:Foo, _2:Foo2) => Foo3){ a; }`,
@@ -449,8 +449,8 @@ describe("verify", function () {
     });
 
     it("5", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         import type Foo2 from 'foo';
         export default function(a: (_1:Foo, ...foo:Array<Foo2>) => number){ a; }`,
         { "no-unused-vars": 1, "no-undef": 1 },
@@ -459,8 +459,8 @@ describe("verify", function () {
     });
 
     it("6", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         export default function(): Foo {}`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
@@ -468,8 +468,8 @@ describe("verify", function () {
     });
 
     it("7", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         export default function():() => Foo {}`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
@@ -477,8 +477,8 @@ describe("verify", function () {
     });
 
     it("8", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         import type Foo2 from 'foo';
         export default function():(_?:Foo) => Foo2{}`,
         { "no-unused-vars": 1, "no-undef": 1 },
@@ -527,8 +527,8 @@ describe("verify", function () {
     });
 
     it("14", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         import type Foo2 from 'foo';
         export default class Bar {set fooProp(value:Foo):Foo2{ value; }}`,
         { "no-unused-vars": 1, "no-undef": 1 },
@@ -537,8 +537,8 @@ describe("verify", function () {
     });
 
     it("15", function () {
-      verifyAndAssertMessages(
-        `import type Foo2 from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo2 from 'foo';
         export default class Foo {get fooProp(): Foo2{}}`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
@@ -546,8 +546,8 @@ describe("verify", function () {
     });
 
     it("16", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         var numVal:Foo; numVal;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
@@ -555,8 +555,8 @@ describe("verify", function () {
     });
 
     it("17", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         var a: {numVal: Foo;}; a;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
@@ -564,8 +564,8 @@ describe("verify", function () {
     });
 
     it("18", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         import type Foo2 from 'foo';
         import type Foo3 from 'foo';
         var a: ?{numVal: Foo; [indexer: Foo2]: Foo3}; a;`,
@@ -575,8 +575,8 @@ describe("verify", function () {
     });
 
     it("19", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         import type Foo2 from 'foo';
         var a: {numVal: Foo; subObj?: ?{strVal: Foo2}}; a;`,
         { "no-unused-vars": 1, "no-undef": 1 },
@@ -585,8 +585,8 @@ describe("verify", function () {
     });
 
     it("20", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         import type Foo2 from 'foo';
         import type Foo3 from 'foo';
         import type Foo4 from 'foo';
@@ -597,8 +597,8 @@ describe("verify", function () {
     });
 
     it("21", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         import type Foo2 from 'foo';
         import type Foo3 from 'foo';
         var a: {add(x:Foo, ...y:Array<Foo2>): Foo3}; a;`,
@@ -608,8 +608,8 @@ describe("verify", function () {
     });
 
     it("22", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         import type Foo2 from 'foo';
         import type Foo3 from 'foo';
         var a: { id<Foo>(x: Foo2): Foo3; }; a;`,
@@ -619,8 +619,8 @@ describe("verify", function () {
     });
 
     it("23", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         var a:Array<Foo> = [1, 2, 3]; a;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
@@ -628,8 +628,8 @@ describe("verify", function () {
     });
 
     it("24", function () {
-      verifyAndAssertMessages(
-        `import type Baz from 'baz';
+      verifyAndAssertMessages(`
+        import type Baz from 'baz';
         export default class Bar<T> extends Baz<T> { };`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
@@ -645,8 +645,8 @@ describe("verify", function () {
     });
 
     it("26", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         import type Foo2 from 'foo';
         export default class Bar { static prop1:Foo; prop2:Foo2; }`,
         { "no-unused-vars": 1, "no-undef": 1 },
@@ -655,8 +655,8 @@ describe("verify", function () {
     });
 
     it("27", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         import type Foo2 from 'foo';
         var x : Foo | Foo2 = 4; x;`,
         { "no-unused-vars": 1, "no-undef": 1 },
@@ -665,8 +665,8 @@ describe("verify", function () {
     });
 
     it("28", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         import type Foo2 from 'foo';
         var x : () => Foo | () => Foo2; x;`,
         { "no-unused-vars": 1, "no-undef": 1 },
@@ -675,8 +675,8 @@ describe("verify", function () {
     });
 
     it("29", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         import type Foo2 from 'foo';
         var x: typeof Foo | number = Foo2; x;`,
         { "no-unused-vars": 1, "no-undef": 1 },
@@ -685,8 +685,8 @@ describe("verify", function () {
     });
 
     it("30", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         var {x}: {x: Foo; } = { x: 'hello' }; x;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
@@ -694,8 +694,8 @@ describe("verify", function () {
     });
 
     it("31", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         var [x]: Array<Foo> = [ 'hello' ]; x;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
@@ -703,8 +703,8 @@ describe("verify", function () {
     });
 
     it("32", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         export default function({x}: { x: Foo; }) { x; }`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
@@ -712,8 +712,8 @@ describe("verify", function () {
     });
 
     it("33", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         function foo([x]: Array<Foo>) { x; } foo();`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
@@ -721,8 +721,8 @@ describe("verify", function () {
     });
 
     it("34", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         import type Foo2 from 'foo';
         var a: Map<Foo, Array<Foo2> >; a;`,
         { "no-unused-vars": 1, "no-undef": 1 },
@@ -731,8 +731,8 @@ describe("verify", function () {
     });
 
     it("35", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         var a: ?Promise<Foo>[]; a;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
@@ -740,8 +740,8 @@ describe("verify", function () {
     });
 
     it("36", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         import type Foo2 from 'foo';
         var a:(...rest:Array<Foo>) => Foo2; a;`,
         { "no-unused-vars": 1, "no-undef": 1 },
@@ -750,8 +750,8 @@ describe("verify", function () {
     });
 
     it("37", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         import type Foo2 from 'foo';
         import type Foo3 from 'foo';
         import type Foo4 from 'foo';
@@ -762,8 +762,8 @@ describe("verify", function () {
     });
 
     it("38", function () {
-      verifyAndAssertMessages(
-        `import type {foo, bar} from 'baz';
+      verifyAndAssertMessages(`
+        import type {foo, bar} from 'baz';
         foo; bar;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
@@ -771,8 +771,8 @@ describe("verify", function () {
     });
 
     it("39", function () {
-      verifyAndAssertMessages(
-        `import type {foo as bar} from 'baz';
+      verifyAndAssertMessages(`
+        import type {foo as bar} from 'baz';
         bar;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
@@ -780,8 +780,8 @@ describe("verify", function () {
     });
 
     it("40", function () {
-      verifyAndAssertMessages(
-        `import type from 'foo';
+      verifyAndAssertMessages(`
+        import type from 'foo';
         type;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
@@ -789,8 +789,8 @@ describe("verify", function () {
     });
 
     it("41", function () {
-      verifyAndAssertMessages(
-        `import type, {foo} from 'bar';
+      verifyAndAssertMessages(`
+        import type, {foo} from 'bar';
         type; foo;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
@@ -798,8 +798,8 @@ describe("verify", function () {
     });
 
     it("42", function () {
-      verifyAndAssertMessages(
-        `import type * as namespace from 'bar';
+      verifyAndAssertMessages(`
+        import type * as namespace from 'bar';
         namespace;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
@@ -807,8 +807,8 @@ describe("verify", function () {
     });
 
     it("43", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         var a: Foo[]; a;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
@@ -816,8 +816,8 @@ describe("verify", function () {
     });
 
     it("44", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         var a: ?Foo[]; a;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
@@ -825,8 +825,8 @@ describe("verify", function () {
     });
 
     it("45", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         var a: (?Foo)[]; a;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
@@ -834,8 +834,8 @@ describe("verify", function () {
     });
 
     it("46", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         var a: () => Foo[]; a;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
@@ -843,8 +843,8 @@ describe("verify", function () {
     });
 
     it("47", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         var a: (() => Foo)[]; a;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
@@ -852,8 +852,8 @@ describe("verify", function () {
     });
 
     it("48", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         var a: typeof Foo[]; a;`,
         { "no-unused-vars": 1, "no-undef": 1 },
         []
@@ -861,8 +861,8 @@ describe("verify", function () {
     });
 
     it("49", function () {
-      verifyAndAssertMessages(
-        `import type Foo from 'foo';
+      verifyAndAssertMessages(`
+        import type Foo from 'foo';
         import type Foo2 from 'foo';
         import type Foo3 from 'foo';
         var a : [Foo, Foo2<Foo3>,] = [123, 'duck',]; a;`,
@@ -881,8 +881,8 @@ describe("verify", function () {
   });
 
   it("class definition: gaearon/redux#24", function () {
-    verifyAndAssertMessages(
-      `export default function root(stores) {
+    verifyAndAssertMessages(`
+      export default function root(stores) {
       return DecoratedComponent => class ReduxRootDecorator {
       a() { DecoratedComponent; stores; }
       };
@@ -909,8 +909,8 @@ describe("verify", function () {
   });
 
   it("template with destructuring #31", function () {
-    verifyAndAssertMessages(
-      `module.exports = {
+    verifyAndAssertMessages(`
+      module.exports = {
       render() {
       var {name} = this.props;
       return Math.max(null, \`Name: \${name}, Name: \${name}\`);
@@ -923,8 +923,8 @@ describe("verify", function () {
 
   describe("decorators #72", function () {
     it("class declaration", function () {
-      verifyAndAssertMessages(
-        `import classDeclaration from 'decorator';
+      verifyAndAssertMessages(`
+        import classDeclaration from 'decorator';
         import decoratorParameter from 'decorator';
         @classDeclaration((parameter) => parameter)
         @classDeclaration(decoratorParameter)
@@ -936,8 +936,8 @@ describe("verify", function () {
     });
 
     it("method definition", function () {
-      verifyAndAssertMessages(
-        `import classMethodDeclarationA from 'decorator';
+      verifyAndAssertMessages(`
+        import classMethodDeclarationA from 'decorator';
         import decoratorParameter from 'decorator';
         export class TextareaAutosize {
         @classMethodDeclarationA((parameter) => parameter)
@@ -953,8 +953,8 @@ describe("verify", function () {
     });
 
     it("method definition get/set", function () {
-      verifyAndAssertMessages(
-        `import classMethodDeclarationA from 'decorator';
+      verifyAndAssertMessages(`
+        import classMethodDeclarationA from 'decorator';
         import decoratorParameter from 'decorator';
         export class TextareaAutosize {
         @classMethodDeclarationA((parameter) => parameter)
@@ -972,8 +972,8 @@ describe("verify", function () {
     });
 
     it("object property", function () {
-      verifyAndAssertMessages(
-        `import classMethodDeclarationA from 'decorator';
+      verifyAndAssertMessages(`
+        import classMethodDeclarationA from 'decorator';
         import decoratorParameter from 'decorator';
         var obj = {
         @classMethodDeclarationA((parameter) => parameter)
@@ -990,8 +990,8 @@ describe("verify", function () {
     });
 
     it("object property get/set", function () {
-      verifyAndAssertMessages(
-        `import classMethodDeclarationA from 'decorator';
+      verifyAndAssertMessages(`
+        import classMethodDeclarationA from 'decorator';
         import decoratorParameter from 'decorator';
         var obj = {
         @classMethodDeclarationA((parameter) => parameter)
@@ -1070,8 +1070,8 @@ describe("verify", function () {
   });
 
   it("don't warn no-unused-vars with spread #142", function () {
-    verifyAndAssertMessages(
-      `export default function test(data) {
+    verifyAndAssertMessages(`
+      export default function test(data) {
       return {
       foo: 'bar',
       ...data
@@ -1083,8 +1083,8 @@ describe("verify", function () {
   });
 
   it("excludes comment tokens #153", function () {
-    verifyAndAssertMessages(
-      `var a = [
+    verifyAndAssertMessages(`
+      var a = [
       1,
       2, // a trailing comment makes this line fail comma-dangle (always-multiline)
       ];`,
@@ -1092,8 +1092,8 @@ describe("verify", function () {
       []
     );
 
-    verifyAndAssertMessages(
-      `switch (a) {
+    verifyAndAssertMessages(`
+      switch (a) {
       // A comment here makes the above line fail brace-style
       case 1:
       console.log(a);
@@ -1112,8 +1112,8 @@ describe("verify", function () {
   });
 
   it("line comment space-in-parens #124", function () {
-    verifyAndAssertMessages(
-      `React.createClass({
+    verifyAndAssertMessages(`
+      React.createClass({
       render() {
       // return (
       //   <div />
@@ -1126,8 +1126,8 @@ describe("verify", function () {
   });
 
   it("block comment space-in-parens #124", function () {
-    verifyAndAssertMessages(
-      `React.createClass({
+    verifyAndAssertMessages(`
+      React.createClass({
       render() {
       /*
       return (
@@ -1156,8 +1156,8 @@ describe("verify", function () {
   });
 
   it("default param flow type no-unused-vars #184", function () {
-    verifyAndAssertMessages(
-      `type ResolveOptionType = {
+    verifyAndAssertMessages(`
+      type ResolveOptionType = {
       depth?: number,
       identifier?: string
       };
@@ -1173,11 +1173,11 @@ describe("verify", function () {
   });
 
   it("no-use-before-define #192", function () {
-    verifyAndAssertMessages(
-      `console.log(x);
+    verifyAndAssertMessages(`
+      console.log(x);
       var x = 1;`,
       { "no-use-before-define": 1 },
-      [ "1:13 'x' was used before it was defined. no-use-before-define" ]
+      [ "2:19 'x' was used before it was defined. no-use-before-define" ]
     );
   });
 
@@ -1190,8 +1190,8 @@ describe("verify", function () {
   });
 
   it("getter/setter #218", function () {
-    verifyAndAssertMessages(
-      `class Person {
+    verifyAndAssertMessages(`
+      class Person {
           set a (v) { }
       }`,
       { "space-before-function-paren": 1, "keyword-spacing": [1, {"before": true}], "indent": 1 },
@@ -1200,8 +1200,8 @@ describe("verify", function () {
   });
 
   it("getter/setter #220", function () {
-    verifyAndAssertMessages(
-      `var B = {
+    verifyAndAssertMessages(`
+      var B = {
       get x () {
       return this.ecks;
       },
@@ -1215,8 +1215,8 @@ describe("verify", function () {
   });
 
   it("fixes issues with flow types and ObjectPattern", function () {
-    verifyAndAssertMessages(
-      `import type Foo from 'bar';
+    verifyAndAssertMessages(`
+      import type Foo from 'bar';
       export default class Foobar {
         foo({ bar }: Foo) { bar; }
         bar({ foo }: Foo) { foo; }
@@ -1227,21 +1227,21 @@ describe("verify", function () {
   });
 
   it("correctly detects redeclares if in script mode #217", function () {
-    verifyAndAssertMessages(
-      `var a = 321;
+    verifyAndAssertMessages(`
+      var a = 321;
       var a = 123;`,
       { "no-redeclare": 1 },
-      [ "2:5 'a' is already defined. no-redeclare" ],
+      [ "3:11 'a' is already defined. no-redeclare" ],
       "script"
     );
   });
 
   it("correctly detects redeclares if in module mode #217", function () {
-    verifyAndAssertMessages(
-      `var a = 321;
+    verifyAndAssertMessages(`
+      var a = 321;
       var a = 123;`,
       { "no-redeclare": 1 },
-      [ "2:5 'a' is already defined. no-redeclare" ],
+      [ "3:11 'a' is already defined. no-redeclare" ],
       "module"
     );
   });
@@ -1286,8 +1286,8 @@ describe("verify", function () {
   });
 
   it("allowImportExportEverywhere option (#327)", function () {
-    verifyAndAssertMessages(
-      `if (true) { import Foo from 'foo'; }
+    verifyAndAssertMessages(`
+      if (true) { import Foo from 'foo'; }
       function foo() { import Bar from 'bar'; }
       switch (a) { case 1: import FooBar from 'foobar'; }`,
       {},
@@ -1326,19 +1326,19 @@ describe("verify", function () {
   });
 
   it("decorator does not create TypeError #229", function () {
-    verifyAndAssertMessages(
-      `class A {
+    verifyAndAssertMessages(`
+      class A {
         @test
         f() {}
       }`,
       { "no-undef": 1 },
-      [ "2:4 'test' is not defined. no-undef" ]
+      [ "3:10 'test' is not defined. no-undef" ]
     );
   });
 
   it("Flow definition does not trigger warnings #223", function () {
-    verifyAndAssertMessages(
-      `import { Map as $Map } from 'immutable';
+    verifyAndAssertMessages(`
+      import { Map as $Map } from 'immutable';
       function myFunction($state: $Map, { a, b, c } : { a: ?Object, b: ?Object, c: $Map }) {}`,
       { "no-dupe-args": 1, "no-redeclare": 1, "no-shadow": 1 },
       []
@@ -1346,8 +1346,8 @@ describe("verify", function () {
   });
 
   it("newline-before-return with comments #289", function () {
-    verifyAndAssertMessages(
-      `function a() {
+    verifyAndAssertMessages(`
+      function a() {
       if (b) {
       /* eslint-disable no-console */
       console.log('test');
@@ -1362,8 +1362,7 @@ describe("verify", function () {
   });
 
   it("spaced-comment with shebang #163", function () {
-    verifyAndAssertMessages(
-      `#!/usr/bin/env babel-node
+    verifyAndAssertMessages(`#!/usr/bin/env babel-node
       import {spawn} from 'foobar';`,
       { "spaced-comment": 1 },
       []
@@ -1372,8 +1371,8 @@ describe("verify", function () {
 
   describe("Class Property Declarations", function() {
     it("no-redeclare false positive 1", function() {
-      verifyAndAssertMessages(
-        `class Group {
+      verifyAndAssertMessages(`
+        class Group {
           static propTypes = {};
         }
         class TypicalForm {
@@ -1385,8 +1384,8 @@ describe("verify", function () {
     });
 
     it("no-redeclare false positive 2", function() {
-      verifyAndAssertMessages(
-        `function validate() {}
+      verifyAndAssertMessages(`
+        function validate() {}
         class MyComponent {
           static validate = validate;
         }`,
@@ -1396,8 +1395,8 @@ describe("verify", function () {
     });
 
     it("check references", function() {
-      verifyAndAssertMessages(
-        `var a;
+      verifyAndAssertMessages(`
+        var a;
         class A {
           prop1;
           prop2 = a;
@@ -1406,7 +1405,7 @@ describe("verify", function () {
         new A`,
         { "no-undef": 1, "no-unused-vars": 1, "no-redeclare": 1 },
         [
-          "5:11 'b' is not defined. no-undef"
+          "6:19 'b' is not defined. no-undef"
         ]
       );
     });

--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -30,13 +30,17 @@ function verifyAndAssertMessages(code, rules, expectedMessages, sourceType, over
   var messages = eslint.linter.verify(code, config);
 
   if (messages.length !== expectedMessages.length) {
-    throw new Error("Expected " + expectedMessages.length + " message(s), got " + messages.length + " " + JSON.stringify(messages));
+    throw new Error(`Expected ${expectedMessages.length} message(s), got ${messages.length} ${JSON.stringify(messages)}`);
   }
 
   messages.forEach(function (message, i) {
-    var formatedMessage = message.line + ":" + message.column + " " + message.message + (message.ruleId ? " " + message.ruleId : "");
+    var formatedMessage = `${message.line}:${message.column} ${message.message}${(message.ruleId ? ` ${message.ruleId}` : "")}`;
     if (formatedMessage !== expectedMessages[i]) {
-      throw new Error("Message " + i + " does not match:\nExpected: " + expectedMessages[i] + "\nActual:   " + formatedMessage);
+      throw new Error(`
+        Message ${i} does not match:
+        Expected: ${expectedMessages[i]}
+        Actual:   ${formatedMessage}`
+      );
     }
   });
 }

--- a/utils/unpad.js
+++ b/utils/unpad.js
@@ -1,0 +1,14 @@
+// Remove padding from a string.
+function unpad(str) {
+  const lines = str.split("\n");
+  const m = lines[1] && lines[1].match(/^\s+/);
+  if (!m) {
+    return str;
+  }
+  const spaces = m[0].length;
+  return lines.map(
+    (line) => line.slice(spaces)
+  ).join("\n").trim();
+}
+
+module.exports = unpad;


### PR DESCRIPTION
The problem with this PR is that using multiline template literals causes indentation to show in the new multiline string where it did not previously with the array join. (an extra 6 spaces is now before most lines)

I have used template literals in all places and the tests all still pass.
