### PR TITLE
Update test for eslint 3.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+yarn.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,16 @@
-git:
-  depth: 1
 sudo: false
 language: node_js
-matrix:
-  include:
-    - node_js: "4"
-    - node_js: "5"
-    - node_js: "6"
+node_js:
+  - "4"
+  - "5"
+  - "6"
 
-script: npm run test-ci
+matrix:
+  fast_finish: true
+  include:
+    - node_js: "node"
+      env: LINT=true
+
+script:
+  - 'if [ -n "${LINT-}" ]; then npm run lint ; fi'
+  - 'if [ -z "${LINT-}" ]; then npm test ; fi'

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   "scripts": {
     "bootstrap": "git submodule update --init && cd eslint && npm install",
     "eslint": "cd eslint && mocha -c tests/lib/rules/*.js -r ../eslint-tester.js",
-    "test": "mocha",
-    "test-ci": "npm test && npm run lint",
+    "test": "npm run lint && npm run test-only",
+    "test-only": "mocha",
     "lint": "eslint index.js babylon-to-espree test",
     "fix": "eslint index.js babylon-to-espree test --fix",
     "preversion": "npm test",

--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -1196,7 +1196,7 @@ describe("verify", function () {
     verifyAndAssertMessages(
       "const {Bacona} = require('baconjs')",
       { "no-undef": 1, "no-unused-vars": 1 },
-      [ "1:8 'Bacona' is defined but never used. no-unused-vars" ]
+      [ "1:8 'Bacona' is assigned a value but never used. no-unused-vars" ]
     );
   });
 


### PR DESCRIPTION
also ignore yarn lock
and run lint only on latest node