### PR TITLE
[import()] Adding support to lint dynamic imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -383,7 +383,8 @@ exports.parseNoPatch = function (code, options) {
       "functionBind",
       "functionSent",
       "objectRestSpread",
-      "trailingFunctionCommas"
+      "trailingFunctionCommas",
+      "dynamicImport"
     ]
   };
 

--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -1573,6 +1573,14 @@ describe("verify", function () {
     });
   });
 
+  it("dynamic import support", function () {
+    verifyAndAssertMessages(
+      "import('test-module').then(() => {})",
+      {},
+      []
+    );
+  });
+
   // it("regex with es6 unicodeCodePointEscapes", function () {
   //   verifyAndAssertMessages(
   //     "string.replace(/[\u{0000A0}-\u{10FFFF}<>\&]/gmiu, (char) => `&#x${char.codePointAt(0).toString(16)};`);",


### PR DESCRIPTION
This adds the `dynamicImport` to the plugin list, which allows `import()` to be parsed.

@hzoo I'm working on getting a babel plugin to transpile these calls into something webpack 1 understands. Would be great to get linter support landed!