### PR TITLE
Revert "use `*`"

### DIFF
--- a/index.js
+++ b/index.js
@@ -370,7 +370,23 @@ exports.parseNoPatch = function (code, options) {
     allowImportExportEverywhere: options.allowImportExportEverywhere, // consistent with espree
     allowReturnOutsideFunction: true,
     allowSuperOutsideMethod: true,
-    plugins: ["*"]
+    plugins: [
+      "flow",
+      "jsx",
+      "asyncFunctions",
+      "asyncGenerators",
+      "classConstructorCall",
+      "classProperties",
+      "decorators",
+      "doExpressions",
+      "exponentiationOperator",
+      "exportExtensions",
+      "functionBind",
+      "functionSent",
+      "objectRestSpread",
+      "trailingFunctionCommas",
+      "dynamicImport"
+    ]
   };
 
   var ast;


### PR DESCRIPTION
Reverts babel/babel-eslint#421

We don't want to recommend this anymore and plan to remove `*` since experimental features will change often