### PR TITLE
[flow] Process polymorphic type bounds on functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -176,6 +176,18 @@ function monkeypatch() {
     }
   }
 
+  function visitTypeParameters(typeParameters) {
+    var params = typeParameters.params;
+
+    // visit bounds on polymorphpic types, eg; `Foo` in `fn<T: Foo>(a: T): T`
+    for (var i = 0; i < params.length; i++) {
+      var param = params[i];
+      if (param.typeAnnotation) {
+        visitTypeAnnotation.call(this, param.typeAnnotation);
+      }
+    }
+  }
+
   function checkIdentifierOrVisit(node) {
     if (node.typeAnnotation) {
       visitTypeAnnotation.call(this, node.typeAnnotation);
@@ -249,6 +261,7 @@ function monkeypatch() {
     var typeParamScope;
     if (node.typeParameters) {
       typeParamScope = nestTypeParamScope(this.scopeManager, node);
+      visitTypeParameters.call(this, node.typeParameters);
     }
     if (node.returnType) {
       checkIdentifierOrVisit.call(this, node.returnType);

--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -222,13 +222,13 @@ describe("verify", () => {
       );
     });
 
-    it("type parameters", () => {
+    it("type parameter bounds", () => {
       verifyAndAssertMessages(
         unpad(`
           import type Foo from 'foo';
           import type Foo2 from 'foo';
-          function log<T1, T2>(a: T1, b: T2) { return a + b; }
-          log<Foo, Foo2>(1, 2);
+          function log<T1: Foo, T2: Foo2>(a: T1, b: T2) { return a + b; }
+          log(1, 2);
         `),
         { "no-unused-vars": 1, "no-undef": 1 },
         []


### PR DESCRIPTION
There was a test that did not test the intended functionality:

```jsx
log<Foo, Foo2>(1, 2)
```
is not a polymorphic function call; such a thing does not appear to exist. Instead, it parses as a SequenceExpression of greater/less-than's: `((log < Foo), (Foo2 > (1, 2)))`. 

This was introduced in [this commit](https://github.com/babel/babel-eslint/commit/8fc39e967c86a1fecfbb4cd09253ac9d54a3e3dd#diff-49183fcdab9e2cd1f1f6c0226baf60d1R173). 

I amended the test to use an imported type inside function parameters, which was the previous 
intent of the code (though it too was incorrect). 

It turns out the amended test failed; `babel-eslint` was not detecting that `Foo` was being used in `fn(T: Foo)`, and raised `no-unused-vars`. 

This PR fixes that bug. 

I also found that the same bug also applies to `declare function`, `declare class`, etc. Unfortunately, I was not able to fix those, as I am new to the eslint / babel-eslint codebase (plus, I'm not familiar with Flow at a deep level). Reported in https://github.com/babel/babel-eslint/issues/445