### PR TITLE
Add option to disable code frame.

### DIFF
--- a/index.js
+++ b/index.js
@@ -366,6 +366,7 @@ exports.parse = function (code, options) {
 
 exports.parseNoPatch = function (code, options) {
   var opts = {
+    codeHighlight: options.hasOwnProperty("codeHighlight") ? options.codeHighlight : true,
     sourceType: options.sourceType,
     allowImportExportEverywhere: options.allowImportExportEverywhere, // consistent with espree
     allowReturnOutsideFunction: true,
@@ -394,14 +395,20 @@ exports.parseNoPatch = function (code, options) {
     ast = parse(code, opts);
   } catch (err) {
     if (err instanceof SyntaxError) {
-      err.lineNumber = err.loc.line;
-      err.column = err.loc.column + 1;
 
-      // remove trailing "(LINE:COLUMN)" acorn message and add in esprima syntax error message start
-      err.message = "Line " + err.lineNumber + ": " + err.message.replace(/ \((\d+):(\d+)\)$/, "") +
-      // add codeframe
-      "\n\n" +
-      codeFrame(code, err.lineNumber, err.column, { highlightCode: true });
+      err.lineNumber = err.loc.line;
+      err.column = err.loc.column;
+
+      if (opts.codeHighlight) {
+        err.lineNumber = err.loc.line;
+        err.column = err.loc.column + 1;
+
+        // remove trailing "(LINE:COLUMN)" acorn message and add in esprima syntax error message start
+        err.message = "Line " + err.lineNumber + ": " + err.message.replace(/ \((\d+):(\d+)\)$/, "") +
+        // add codeframe
+        "\n\n" +
+        codeFrame(code, err.lineNumber, err.column, { highlightCode: true });
+      }
     }
 
     throw err;

--- a/index.js
+++ b/index.js
@@ -366,7 +366,7 @@ exports.parse = function (code, options) {
 
 exports.parseNoPatch = function (code, options) {
   var opts = {
-    codeHighlight: options.hasOwnProperty("codeHighlight") ? options.codeHighlight : true,
+    codeFrame: options.hasOwnProperty("codeFrame") ? options.codeFrame : true,
     sourceType: options.sourceType,
     allowImportExportEverywhere: options.allowImportExportEverywhere, // consistent with espree
     allowReturnOutsideFunction: true,
@@ -399,7 +399,7 @@ exports.parseNoPatch = function (code, options) {
       err.lineNumber = err.loc.line;
       err.column = err.loc.column;
 
-      if (opts.codeHighlight) {
+      if (opts.codeFrame) {
         err.lineNumber = err.loc.line;
         err.column = err.loc.column + 1;
 

--- a/test/fixtures/rules/syntax-error.js
+++ b/test/fixtures/rules/syntax-error.js
@@ -1,0 +1,6 @@
+class ClassName {
+  constructor() {
+
+  },
+  aMethod() {}
+}

--- a/test/integration.js
+++ b/test/integration.js
@@ -200,4 +200,46 @@ function strictSuite () {
     // it
   });
   // describe
+  describe("When \"codeFrame\"", () => {
+    it("should display codeFrame when option is absent", (done) => {
+      lint({
+        fixture: ["syntax-error"],
+        eslint: baseEslintOpts
+      }, (err, report) => {
+        if (err) return done(err);
+        assert(report[0].message.indexOf("^\n  5 |") > -1);
+        done();
+      });
+    });
+
+    it("should display codeFrame when option is true", (done) => {
+      lint({
+        fixture: ["syntax-error"],
+        eslint: Object.assign({}, baseEslintOpts, {
+          parserOptions: {
+            codeFrame: true
+          }
+        })
+      }, (err, report) => {
+        if (err) return done(err);
+        assert(report[0].message.indexOf("^\n  5 |") > -1);
+        done();
+      });
+    });
+
+    it("should not display codeFrame when option is false", (done) => {
+      lint({
+        fixture: ["syntax-error"],
+        eslint: Object.assign({}, baseEslintOpts, {
+          parserOptions: {
+            codeFrame: false
+          }
+        })
+      }, (err, report) => {
+        if (err) return done(err);
+        assert(report[0].message.indexOf("^\n  5 |") === -1);
+        done();
+      });
+    });
+  });
 }

--- a/test/integration.js
+++ b/test/integration.js
@@ -201,13 +201,19 @@ function strictSuite () {
   });
   // describe
   describe("When \"codeFrame\"", () => {
+    // Strip chalk colors, these are not relevant for the test
+    const stripAnsi = (str) => str.replace(
+      /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g,
+      ""
+    );
+
     it("should display codeFrame when option is absent", (done) => {
       lint({
         fixture: ["syntax-error"],
         eslint: baseEslintOpts
       }, (err, report) => {
         if (err) return done(err);
-        assert(report[0].message.indexOf("^\n  5 |") > -1);
+        assert(stripAnsi(report[0].message).indexOf("^\n  5 |") > -1);
         done();
       });
     });
@@ -222,7 +228,7 @@ function strictSuite () {
         })
       }, (err, report) => {
         if (err) return done(err);
-        assert(report[0].message.indexOf("^\n  5 |") > -1);
+        assert(stripAnsi(report[0].message).indexOf("^\n  5 |") > -1);
         done();
       });
     });
@@ -237,7 +243,7 @@ function strictSuite () {
         })
       }, (err, report) => {
         if (err) return done(err);
-        assert(report[0].message.indexOf("^\n  5 |") === -1);
+        assert(stripAnsi(report[0].message).indexOf("^\n  5 |") === -1);
         done();
       });
     });


### PR DESCRIPTION
This might sound weird, since code frame is a great feature of babel-eslint.

My use case:

I want to display eslint reports in [go.cd](https://www.gocd.io/), for that I need to generate an HTML report, which is usually easy with eslint HTML formatter, and it results in something like this:

<img width="1023" alt="screen shot 2017-03-19 at 14 14 07" src="https://cloud.githubusercontent.com/assets/165314/24081574/6ed1c632-0cae-11e7-90f5-12a8bb319522.png">

However with babel-eslint, due to the code frame feature the same report looks like this:

<img width="1025" alt="screen shot 2017-03-19 at 14 15 45" src="https://cloud.githubusercontent.com/assets/165314/24081586/93729f52-0cae-11e7-93a2-6b7ba28b9539.png">

This PR adds an option to `parserOptions` to disable the code highlight feature, and when enabled, it simply returns the regular exepected output to eslint, so... when `.eslintrc` looks something like this:

```
{
  "parser": "babel-eslint",
  "parserOptions": {
    "codeFrame": false
  },
  "extends": "eslint:recommended"
}
```

the generated HTML will look similar to this:

<img width="1030" alt="screen shot 2017-03-19 at 14 20 59" src="https://cloud.githubusercontent.com/assets/165314/24081630/73e87836-0caf-11e7-92ed-a33135acd787.png">

I hope this PR is good enough to merge, however if anything is needed, please just say so :)