### PR TITLE
Remove lodash dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 var babylonToEspree = require("./babylon-to-espree");
-var pick            = require("lodash").pickBy;
 var Module          = require("module");
 var path            = require("path");
 var parse           = require("babylon").parse;
@@ -100,18 +99,23 @@ function monkeypatch() {
   }
 
   // iterate through part of t.VISITOR_KEYS
-  var visitorKeysMap = pick(t.VISITOR_KEYS, (k) => {
-    return t.FLIPPED_ALIAS_KEYS.Flow.concat([
-      "ArrayPattern",
-      "ClassDeclaration",
-      "ClassExpression",
-      "FunctionDeclaration",
-      "FunctionExpression",
-      "Identifier",
-      "ObjectPattern",
-      "RestElement"
-    ]).indexOf(k) === -1;
-  });
+  var flowFlippedAliasKeys = t.FLIPPED_ALIAS_KEYS.Flow.concat([
+    "ArrayPattern",
+    "ClassDeclaration",
+    "ClassExpression",
+    "FunctionDeclaration",
+    "FunctionExpression",
+    "Identifier",
+    "ObjectPattern",
+    "RestElement"
+  ]);
+  var visitorKeysMap = Object.keys(t.VISITOR_KEYS).reduce(function(acc, key) {
+    var value = t.VISITOR_KEYS[key];
+    if (flowFlippedAliasKeys.indexOf(value) === -1) {
+      acc[key] = value;
+    }
+    return acc;
+  }, {});
 
   var propertyTypes = {
     // loops

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "babel-code-frame": "^6.22.0",
     "babel-traverse": "^6.23.1",
     "babel-types": "^6.23.0",
-    "babylon": "^6.16.1",
-    "lodash": "^4.17.4"
+    "babylon": "^6.16.1"
   },
   "scripts": {
     "test": "npm run lint && npm run test-only",

--- a/yarn.lock
+++ b/yarn.lock
@@ -694,7 +694,7 @@ lodash.pickby@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.pickby/-/lodash.pickby-4.6.0.tgz#7dea21d8c18d7703a27c704c15d3b84a67e33aff"
 
-lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.15.0, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 


### PR DESCRIPTION
#435 switched `lodash.pickby` to `lodash` to reduce the size of the dependency tree (since `lodash` would be shared with `babel-types` and `babel-traverse`). Although it did do that, it ended up loading all of `lodash`. It should've done `require('lodash/pickBy')` instead of `require('lodash').pickBy`. However, since `babel-*` doesn't use `pickBy`, we'd load those deps for no reason. Since it's a trivial function to implement with native functions, this PR does that instead.