### PR TITLE
Format non-regression errors for legibility

### DIFF
--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -31,7 +31,7 @@ function verifyAndAssertMessages(code, rules, expectedMessages, sourceType, over
   var messages = eslint.linter.verify(code, config);
 
   if (messages.length !== expectedMessages.length) {
-    throw new Error(`Expected ${expectedMessages.length} message(s), got ${messages.length} ${JSON.stringify(messages)}`);
+    throw new Error(`Expected ${expectedMessages.length} message(s), got ${messages.length}\n${JSON.stringify(messages, null, 2)}`);
   }
 
   messages.forEach((message, i) => {


### PR DESCRIPTION
These are hard to read when you're debugging.

Before:

```
  1) verify flow type in var declaration:
     Error: Expected 0 message(s), got 1 [{"ruleId":"no-unused-vars","severity":1,"message":"'x' is assigned a value but never used.","line":2,"column":5,"nodeType":"Identifier","source":"var x: Foo = 1;"}]
      at verifyAndAssertMessages (test/non-regression.js:34:11)
      at Context.it (test/non-regression.js:253:7)
```

After:

```
  1) verify flow type in var declaration:
     Error: Expected 0 message(s), got 1
[
  {
    "ruleId": "no-unused-vars",
    "severity": 1,
    "message": "'x' is assigned a value but never used.",
    "line": 2,
    "column": 5,
    "nodeType": "Identifier",
    "source": "var x: Foo = 1;"
  }
]
      at verifyAndAssertMessages (test/non-regression.js:34:11)
      at Context.it (test/non-regression.js:253:7)
```