### PR TITLE
Correctly create visitorKeysMap

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,9 +105,8 @@ function monkeypatch() {
     "RestElement"
   ]);
   var visitorKeysMap = Object.keys(t.VISITOR_KEYS).reduce(function(acc, key) {
-    var value = t.VISITOR_KEYS[key];
-    if (flowFlippedAliasKeys.indexOf(value) === -1) {
-      acc[key] = value;
+    if (flowFlippedAliasKeys.indexOf(key) !== -1) {
+      acc[key] = t.VISITOR_KEYS[key];
     }
     return acc;
   }, {});


### PR DESCRIPTION
`visitorKeysMap` has always been a copy of `t.VISITOR_KEYS`. After doing some archeology, it seems like there's been confusion wrt lodash's `pick` vs `pickBy`, which led to this.

When `visitorKeysMap` was first introduced in #109, it used `lodash.pick@3`. In that version, the predicate was called with `(value, key, object)`. It was later switched to `lodash.pickby@4` in #301. Because in `lodash@4`, `pick` switched to calling the predicate with `(key, value, object)`, and `pickby` kept the old `pick` behavior. Throughout this, the value passed to `indexOf` was always an array (those are the values of `t.VISITOR_KEYS`), and `indexOf` was comparing that to strings (the values of `t.FLIPPED_ALIAS_KEYS.Flow`). So that meant that `-1 === -1` and `visitorKeysMap` became a shallow copy of `t.VISITOR_KEYS`. #450 didn't help because it copied the same behavior.

This is a very big change. I ran this against the tests in https://github.com/gajus/eslint-plugin-flowtype and on a full eslint run of https://github.com/facebook/nuclide - and `babel-eslint` continues to work.