### PR TITLE
Tidy up babylon-to-espree

### DIFF
--- a/babylon-to-espree/attachComments.js
+++ b/babylon-to-espree/attachComments.js
@@ -1,3 +1,5 @@
+"use strict";
+
 // comment fixes
 module.exports = function (ast, comments, tokens) {
   if (comments.length) {

--- a/babylon-to-espree/convertComments.js
+++ b/babylon-to-espree/convertComments.js
@@ -1,3 +1,5 @@
+"use strict";
+
 module.exports = function (comments) {
   for (var i = 0; i < comments.length; i++) {
     var comment = comments[i];

--- a/babylon-to-espree/convertComments.js
+++ b/babylon-to-espree/convertComments.js
@@ -1,0 +1,15 @@
+module.exports = function (comments) {
+  for (var i = 0; i < comments.length; i++) {
+    var comment = comments[i];
+    if (comment.type === "CommentBlock") {
+      comment.type = "Block";
+    } else if (comment.type === "CommentLine") {
+      comment.type = "Line";
+    }
+    // sometimes comments don't get ranges computed,
+    // even with options.ranges === true
+    if (!comment.range) {
+      comment.range = [comment.start, comment.end];
+    }
+  }
+};

--- a/babylon-to-espree/convertTemplateType.js
+++ b/babylon-to-espree/convertTemplateType.js
@@ -1,3 +1,5 @@
+"use strict";
+
 module.exports = function (tokens, tt) {
   var startingToken    = 0;
   var currentToken     = 0;

--- a/babylon-to-espree/index.js
+++ b/babylon-to-espree/index.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var attachComments  = require("./attachComments");
 var convertComments = require("./convertComments");
 var toTokens        = require("./toTokens");

--- a/babylon-to-espree/index.js
+++ b/babylon-to-espree/index.js
@@ -1,6 +1,34 @@
-exports.attachComments = require("./attachComments");
+var attachComments  = require("./attachComments");
+var convertComments = require("./convertComments");
+var toTokens        = require("./toTokens");
+var toAST           = require("./toAST");
 
-exports.toTokens       = require("./toTokens");
-exports.toAST          = require("./toAST");
+module.exports = function (ast, traverse, tt, code) {
+  // remove EOF token, eslint doesn't use this for anything and it interferes
+  // with some rules see https://github.com/babel/babel-eslint/issues/2
+  // todo: find a more elegant way to do this
+  ast.tokens.pop();
 
-exports.convertComments = require("./convertComments");
+  // convert tokens
+  ast.tokens = toTokens(ast.tokens, tt, code);
+
+  // add comments
+  convertComments(ast.comments);
+
+  // transform esprima and acorn divergent nodes
+  toAST(ast, traverse, code);
+
+  // ast.program.tokens = ast.tokens;
+  // ast.program.comments = ast.comments;
+  // ast = ast.program;
+
+  // remove File
+  ast.type = "Program";
+  ast.sourceType = ast.program.sourceType;
+  ast.directives = ast.program.directives;
+  ast.body = ast.program.body;
+  delete ast.program;
+  delete ast._paths;
+
+  attachComments(ast, ast.comments, ast.tokens);
+};

--- a/babylon-to-espree/index.js
+++ b/babylon-to-espree/index.js
@@ -3,18 +3,4 @@ exports.attachComments = require("./attachComments");
 exports.toTokens       = require("./toTokens");
 exports.toAST          = require("./toAST");
 
-exports.convertComments = function (comments) {
-  for (var i = 0; i < comments.length; i++) {
-    var comment = comments[i];
-    if (comment.type === "CommentBlock") {
-      comment.type = "Block";
-    } else if (comment.type === "CommentLine") {
-      comment.type = "Line";
-    }
-    // sometimes comments don't get ranges computed,
-    // even with options.ranges === true
-    if (!comment.range) {
-      comment.range = [comment.start, comment.end];
-    }
-  }
-};
+exports.convertComments = require("./convertComments");

--- a/babylon-to-espree/toAST.js
+++ b/babylon-to-espree/toAST.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var convertComments = require("./convertComments");
 
 module.exports = function (ast, traverse, code) {

--- a/babylon-to-espree/toAST.js
+++ b/babylon-to-espree/toAST.js
@@ -1,3 +1,5 @@
+var convertComments = require("./convertComments");
+
 module.exports = function (ast, traverse, code) {
   var state = { source: code };
   ast.range = [ast.start, ast.end];
@@ -12,18 +14,6 @@ function changeToLiteral(node, state) {
     } else {
       node.raw = state.source.slice(node.start, node.end);
     }
-  }
-}
-
-function changeComments(nodeComments) {
-  for (var i = 0; i < nodeComments.length; i++) {
-    var comment = nodeComments[i];
-    if (comment.type === "CommentLine") {
-      comment.type = "Line";
-    } else if (comment.type === "CommentBlock") {
-      comment.type = "Block";
-    }
-    comment.range = [comment.start, comment.end];
   }
 }
 
@@ -43,11 +33,11 @@ var astTransformVisitor = {
     }
 
     if (node.trailingComments) {
-      changeComments(node.trailingComments);
+      convertComments(node.trailingComments);
     }
 
     if (node.leadingComments) {
-      changeComments(node.leadingComments);
+      convertComments(node.leadingComments);
     }
 
     // make '_paths' non-enumerable (babel-eslint #200)

--- a/babylon-to-espree/toAST.js
+++ b/babylon-to-espree/toAST.js
@@ -215,7 +215,8 @@ var astTransformVisitor = {
 
     // template string range fixes
     if (path.isTemplateLiteral()) {
-      node.quasis.forEach((q) => {
+      for (var j = 0; j < node.quasis.length; j++) {
+        var q = node.quasis[j];
         q.range[0] -= 1;
         if (q.tail) {
           q.range[1] += 1;
@@ -228,7 +229,7 @@ var astTransformVisitor = {
         } else {
           q.loc.end.column += 2;
         }
-      });
+      }
     }
   }
 };

--- a/babylon-to-espree/toToken.js
+++ b/babylon-to-espree/toToken.js
@@ -1,3 +1,5 @@
+"use strict";
+
 module.exports = function (token, tt, source) {
   var type = token.type;
   token.range = [token.start, token.end];

--- a/babylon-to-espree/toTokens.js
+++ b/babylon-to-espree/toTokens.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var convertTemplateType = require("./convertTemplateType");
 var toToken = require("./toToken");
 

--- a/babylon-to-espree/toTokens.js
+++ b/babylon-to-espree/toTokens.js
@@ -4,12 +4,13 @@ var toToken = require("./toToken");
 module.exports = function (tokens, tt, code) {
   // transform tokens to type "Template"
   convertTemplateType(tokens, tt);
-  var transformedTokens = tokens.filter((token) => {
-    return token.type !== "CommentLine" && token.type !== "CommentBlock";
-  });
 
-  for (var i = 0, l = transformedTokens.length; i < l; i++) {
-    transformedTokens[i] = toToken(transformedTokens[i], tt, code);
+  var transformedTokens = [];
+  for (var i = 0; i < tokens.length; i++) {
+    var token = tokens[i];
+    if (token.type !== "CommentLine" && token.type !== "CommentBlock") {
+      transformedTokens.push(toToken(token, tt, code));
+    }
   }
 
   return transformedTokens;

--- a/index.js
+++ b/index.js
@@ -428,33 +428,7 @@ exports.parseNoPatch = function (code, options) {
     throw err;
   }
 
-  // remove EOF token, eslint doesn't use this for anything and it interferes with some rules
-  // see https://github.com/babel/babel-eslint/issues/2 for more info
-  // todo: find a more elegant way to do this
-  ast.tokens.pop();
-
-  // convert tokens
-  ast.tokens = babylonToEspree.toTokens(ast.tokens, tt, code);
-
-  // add comments
-  babylonToEspree.convertComments(ast.comments);
-
-  // transform esprima and acorn divergent nodes
-  babylonToEspree.toAST(ast, traverse, code);
-
-  // ast.program.tokens = ast.tokens;
-  // ast.program.comments = ast.comments;
-  // ast = ast.program;
-
-  // remove File
-  ast.type = "Program";
-  ast.sourceType = ast.program.sourceType;
-  ast.directives = ast.program.directives;
-  ast.body = ast.program.body;
-  delete ast.program;
-  delete ast._paths;
-
-  babylonToEspree.attachComments(ast, ast.comments, ast.tokens);
+  babylonToEspree(ast, traverse, tt, code);
 
   return ast;
 };


### PR DESCRIPTION
The only "breaking" change are the exports of `babylon-to-espree`. That wasn't part of the public API, so hopefully nobody is using them.