### PR TITLE
RFC: Do not set a default ecmaVersion or sourceType

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ $ npm install eslint@3.x babel-eslint@6 --save-dev
 ```json
 {
   "parser": "babel-eslint",
+  "parserOptions": {
+    "ecmaVersion": 8,
+    "sourceType": "module"
+  },
   "rules": {
     "strict": 0
   }
@@ -76,19 +80,42 @@ Check out the [ESLint docs](http://eslint.org/docs/rules/) for all possible rule
 
 ### Configuration
 
-`sourceType` can be set to `'module'`(default) or `'script'` if your code isn't using ECMAScript modules.
-`allowImportExportEverywhere` can be set to true to allow import and export declarations to appear anywhere a statement is allowed if your build environment supports that. By default, import and export declarations can only appear at a program's top level.
-`codeFrame` can be set to false to disable the code frame in the reporter. This is useful since some eslint formatters don't play well with it.
+* `sourceType`, `ecmaVersion`, `ecmaFeatures.globalReturn` and `ecmaFeatures.impliedStrict` should be set in accordance with http://eslint.org/docs/user-guide/configuring#specifying-parser-options.
+  - `ecmaVersion` is disregarded by `babel-eslint`, however, some ESlint rules depend on this value being set correctly.
+  - If `sourceType` is not set to `"module"`, then using `import`/`export` will error.
+* `allowImportExportEverywhere` (default `false`) can be set to `true` to allow import and export declarations to appear anywhere a statement is allowed if your build environment supports that. By default, import and export declarations can only appear at a program's top level.
+* `allowSuperOutsideMethod` (default `true`) can be set to `false` to disallow use of `super` outside of methods. **Note:** Babel's default is `false`.
+* `codeFrame` can be set to false to disable the code frame in the reporter. This is useful since some ESlint formatters don't play well with it.
 
-**.eslintrc**
+#### `.eslintrc`
+
+**Recommended:**
 
 ```json
 {
   "parser": "babel-eslint",
   "parserOptions": {
-    "sourceType": "module",
+    "ecmaVersion": 8,
+    "sourceType": "module"
+  }
+}
+```
+
+**Defaults:**
+
+```json
+{
+  "parser": "babel-eslint",
+  "parserOptions": {
+    "ecmaVersion": 5,
+    "sourceType": "script",
+    "ecmaFeatures": {
+      "globalReturn": false,
+      "impliedStrict": false
+    },
     "allowImportExportEverywhere": false,
-    "codeFrame": false
+    "allowSuperOutsideMethod": true,
+    "codeFrame": true
   }
 }
 ```

--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -18,7 +18,7 @@ function verifyAndAssertMessages(code, rules, expectedMessages, sourceType, over
         experimentalObjectRestSpread: true,
         globalReturn: true
       },
-      sourceType
+      sourceType: sourceType || "module"
     }
   };
 
@@ -1566,28 +1566,11 @@ describe("verify", () => {
     verifyAndAssertMessages(
       "var leakedGlobal = 1;",
       { "no-implicit-globals": 1 },
-      [],
+      [ "1:5 Implicit global variable, assign as global property instead. no-implicit-globals" ],
       null,
       {
         env: {},
         parserOptions: { ecmaVersion: 6 }
-      }
-    );
-  });
-
-  it("allowImportExportEverywhere option (#327)", () => {
-    verifyAndAssertMessages(
-      unpad(`
-        if (true) { import Foo from 'foo'; }
-        function foo() { import Bar from 'bar'; }
-        switch (a) { case 1: import FooBar from 'foobar'; }
-      `),
-      {},
-      [],
-      "module",
-      {
-        env: {},
-        parserOptions: { ecmaVersion: 6, sourceType: "module", allowImportExportEverywhere: true }
       }
     );
   });


### PR DESCRIPTION
This is a super breaking change, but it ensures correctness in ESLint's rules, and eliminates surprises.

Before this change, `babel-eslint` set defaults for `sourceType` and `ecmaVersion` that it applied to Babylon and escope. However, these values could not propagate to the ESLint rules themselves or ESLint APIs. This resulted in incorrect behavior by certain rules. Consider these examples:

* https://github.com/eslint/eslint/blob/6a718ba/lib/eslint.js#L1093-L1101
* https://github.com/eslint/eslint/blob/6a718ba/lib/rules/func-name-matching.js#L40-L51
* https://github.com/eslint/eslint/blob/6a718ba/lib/rules/no-redeclare.js#L86-L98

Making things even more surprising is the fact that setting `env: es6` sets the `ecmaVersion` to `6` but doesn't change `sourceType` (https://github.com/eslint/eslint/blob/6a718ba/conf/environments.js#L98-L103).