### PR TITLE
[WIP] Refactor visiting strategy

### DIFF
--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -206,6 +206,17 @@ describe("verify", () => {
       );
     });
 
+    it("nameless function type param", () => {
+      verifyAndAssertMessages(
+        unpad(`
+          import type Foo from '';
+          type T = (string, b: Foo) => void; T;
+        `),
+        { "no-unused-vars": 1, "no-undef": 1 },
+        []
+      );
+    });
+
     it("multiple nullable type annotations and return #108", () => {
       verifyAndAssertMessages(
         unpad(`
@@ -371,6 +382,27 @@ describe("verify", () => {
         [ "1:1 'T' is not defined. no-undef",
           "2:14 'T' is defined but never used. no-unused-vars",
           "3:1 'T' is not defined. no-undef" ]
+      );
+    });
+
+    it("type parameter bounds with nested function (function type)", () => {
+      verifyAndAssertMessages(
+        unpad(`
+          type T<U> = <V>() => U;
+        `),
+        { "no-unused-vars": 1, "no-undef": 1 },
+        [ "1:6 'T' is defined but never used. no-unused-vars",
+          "1:14 'V' is defined but never used. no-unused-vars" ]
+      );
+    });
+
+    it("type parameter bounds with nested function #2 (function type)", () => {
+      verifyAndAssertMessages(
+        unpad(`
+          type T<U> = <V: T>(a: {b: U}) => V;
+        `),
+        { "no-unused-vars": 1, "no-undef": 1 },
+        [ ]
       );
     });
 
@@ -872,10 +904,11 @@ describe("verify", () => {
           import type Foo from 'foo';
           import type Foo2 from 'foo';
           import type Foo3 from 'foo';
-          var a: { id<Foo>(x: Foo2): Foo3; }; a;
+          var a: { id<Foo, Bar>(x: Foo2, y: Bar): Foo3; }; a;
         `),
         { "no-unused-vars": 1, "no-undef": 1 },
-        []
+        [ "1:13 'Foo' is defined but never used. no-unused-vars",
+          "4:13 'Foo' is defined but never used. no-unused-vars" ]
       );
     });
 
@@ -1043,10 +1076,10 @@ describe("verify", () => {
           import type Foo2 from 'foo';
           import type Foo3 from 'foo';
           import type Foo4 from 'foo';
-          var a: <Foo>(x: Foo2, ...y:Foo3[]) => Foo4; a;
+          var a: <T: Foo>(x: Foo2, ...y:Foo3[]) => Foo4; a;
         `),
         { "no-unused-vars": 1, "no-undef": 1 },
-        []
+        [ "5:9 'T' is defined but never used. no-unused-vars" ]
       );
     });
 

--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -265,6 +265,28 @@ describe("verify", () => {
       );
     });
 
+    it("type parameter scope #2 (classes)", () => {
+      verifyAndAssertMessages(
+        unpad(`
+          (class C<T: C<*>, U> { t: T; });
+        `),
+        { "no-unused-vars": 1, "no-undef": 1 },
+        [ "1:19 'U' is defined but never used. no-unused-vars" ]
+      );
+    });
+
+    it("type parameter scope #3 (classes)", () => {
+      verifyAndAssertMessages(
+        unpad(`
+          class D {}
+          (class C<T: C<*>, U> extends D<T, V> { });
+        `),
+        { "no-unused-vars": 1, "no-undef": 1 },
+        [ "2:19 'U' is defined but never used. no-unused-vars",
+          "2:35 'V' is not defined. no-undef" ]
+      );
+    });
+
     it("type parameter bounds (interfaces)", () => {
       verifyAndAssertMessages(
         unpad(`
@@ -349,6 +371,16 @@ describe("verify", () => {
         [ "1:1 'T' is not defined. no-undef",
           "2:14 'T' is defined but never used. no-unused-vars",
           "3:1 'T' is not defined. no-undef" ]
+      );
+    });
+
+    it("type parameter scope #2 (functions)", () => {
+      verifyAndAssertMessages(
+        unpad(`
+          (function C<T: C<*>, U>(): T { });
+        `),
+        { "no-unused-vars": 1, "no-undef": 1 },
+        [ "1:22 'U' is defined but never used. no-unused-vars" ]
       );
     });
 
@@ -557,6 +589,35 @@ describe("verify", () => {
         `),
         { "no-unused-vars": 1, "no-undef": 1 },
         [ "2:30 'T' is not defined. no-undef" ]
+      );
+    });
+
+    it("class property decorators + types", () => {
+      verifyAndAssertMessages(
+        unpad(`
+          import T from '';
+          class C {
+            @foo
+            i: T = 0;
+          }
+          new C();
+        `),
+        { "no-unused-vars": 1, "no-undef": 1 },
+        [ "3:4 'foo' is not defined. no-undef" ]
+      );
+    });
+
+    it("class property type cast", () => {
+      verifyAndAssertMessages(
+        unpad(`
+          import {T, i} from '';
+          class C {
+            p = (i: T)
+          }
+          new C();
+        `),
+        { "no-unused-vars": 1, "no-undef": 1 },
+        [ ]
       );
     });
 
@@ -1435,14 +1496,14 @@ describe("verify", () => {
     verifyAndAssertMessages(
       unpad(`
         type ResolveOptionType = {
-        depth?: number,
-        identifier?: string
+          depth?: number,
+          identifier?: string
         };
 
         export default function resolve(
-        options: ResolveOptionType = {}
+          options: ResolveOptionType = {}
         ): Object {
-        options;
+          options;
         }
       `),
       { "no-unused-vars": 1, "no-undef": 1 },


### PR DESCRIPTION
This PR does away with the custom traverser, and instead adds correct node visitors to get accurate scopes (and references/definitions) for flow types. It's written for easy upstreaming into `eslint-scope` (see #438) if that becomes a thing. How? New node type visitors are added (look for `//new`), and only node type visitors were overwritten (look for `//override`) instead of `visit*` functions. There's some copy/paste from escope in the overwritten methods to clearly show where the new flow type code must go (look for `<custom></custom>`).

#### TODO:

- [ ]  Fix `declare` (Correct scoping, especially with `declare module`).
- [ ] More scope tests.