### PR TITLE
Fix: use eslint-scope instead of escope if present

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,10 +28,17 @@ function getModules() {
   eslintMod.filename = eslintLoc;
   eslintMod.paths = Module._nodeModulePaths(path.dirname(eslintLoc));
 
-  var Definition = eslintMod.require("escope/lib/definition").Definition;
-  var escope  = eslintMod.require("escope");
+  try {
+    var escope = eslintMod.require("eslint-scope");
+    var Definition = eslintMod.require("eslint-scope/lib/definition").Definition;
+    var referencer = eslintMod.require("eslint-scope/lib/referencer");
+  } catch (err) {
+    escope  = eslintMod.require("escope");
+    Definition = eslintMod.require("escope/lib/definition").Definition;
+    referencer = eslintMod.require("escope/lib/referencer");
+  }
+
   var estraverse = eslintMod.require("estraverse");
-  var referencer = eslintMod.require("escope/lib/referencer");
 
   if (referencer.__esModule) referencer = referencer.default;
 


### PR DESCRIPTION
This PR fixes a problem with the v4-alpha release of ESLint.

Since in v4 `eslint` dropped the `escope` dependency in favor of `eslint-scope`, `babel-eslint` will throw an error when attempting to load `escope` inside the `getModules()` function.

This changes the `getModules()` function to first try to load `eslint-scope`, and only attempt to load `escope` as a fallback (so `babel-eslint` continues to work with pre-v4 ESLint too).

I created a repository with a reproduction case for this bug: https://github.com/vitorbal/babel_eslint_v4_repro
The repository also has 2 branches `eslint_v4_with_fix` and `eslint_v3_with_fix` which shows the fix from this PR in action. See the repo's README for more info.

Let me know if this makes sense and if anything else is needed – this is my first contribution to `babel-eslint`. Thanks! :)