### PR TITLE
Update handling of .properties for compatibility with babel@7

### DIFF
--- a/babylon-to-espree/toAST.js
+++ b/babylon-to-espree/toAST.js
@@ -165,8 +165,12 @@ var astTransformVisitor = {
       delete node.typeParameters;
     }
 
-    if (path.isRestProperty() || path.isSpreadProperty()) {
-      node.type = `Experimental${node.type}`;
+    if (node.type !== 'Property' && path.isRestProperty()) {
+      node.type = `ExperimentalRestProperty`;
+    }
+
+    if (node.type !== 'Property' && path.isSpreadProperty()) {
+      node.type = `ExperimentalSpreadProperty`;
     }
 
     if (path.isTypeParameter && path.isTypeParameter()) {

--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ function monkeypatch(modules) {
     // loops
     callProperties: { type: "loop", values: ["value"] },
     indexers: { type: "loop", values: ["key", "value"] },
-    properties: { type: "loop", values: ["value"] },
+    properties: { type: "props" },
     types: { type: "loop" },
     params: { type: "loop" },
     // single property
@@ -138,6 +138,7 @@ function monkeypatch(modules) {
       if (propertyType == null || nodeProperty == null) {
         continue;
       }
+
       if (propertyType.type === "loop") {
         for (var j = 0; j < nodeProperty.length; j++) {
           if (Array.isArray(propertyType.values)) {
@@ -146,6 +147,16 @@ function monkeypatch(modules) {
             }
           } else {
             checkIdentifierOrVisit.call(this, nodeProperty[j]);
+          }
+        }
+      } else if (propertyType.type === 'props') {
+        // Props may have either .value or .argument depending on element type. 
+        for (var j = 0; j < nodeProperty.length; j++) {
+          const currentNodeProperty = nodeProperty[j];
+          if (currentNodeProperty.argument) {
+            visitTypeAnnotation.call(this, currentNodeProperty);
+          } else {
+            checkIdentifierOrVisit.call(this, currentNodeProperty.value);
           }
         }
       } else if (propertyType.type === "single") {

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     "url": "https://github.com/babel/babel-eslint.git"
   },
   "dependencies": {
-    "babel-code-frame": "^6.22.0",
-    "babel-traverse": "^6.23.1",
-    "babel-types": "^6.23.0",
-    "babylon": "^6.16.1"
+    "babel-code-frame": "^7.0.0-alpha.9",
+    "babel-traverse": "^7.0.0-alpha.9",
+    "babel-types": "^7.0.0-alpha.9",
+    "babylon": "^7.0.0-alpha.9"
   },
   "scripts": {
     "test": "npm run lint && npm run test-only",

--- a/yarn.lock
+++ b/yarn.lock
@@ -59,6 +59,14 @@ arrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
+babel-code-frame@7.0.0-alpha.9, babel-code-frame@^7.0.0-alpha.9:
+  version "7.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-7.0.0-alpha.9.tgz#b861deec3e9f744a30405137d4ad0216ccef0cba"
+  dependencies:
+    chalk "^1.1.0"
+    esutils "^2.0.2"
+    js-tokens "^3.0.0"
+
 babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
@@ -77,6 +85,10 @@ babel-eslint@^7.0.0:
     babylon "^6.13.0"
     lodash.pickby "^4.6.0"
 
+babel-messages@7.0.0-alpha.9:
+  version "7.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-7.0.0-alpha.9.tgz#472b5e7158c4b3fded5eec0fb76f0ad930cb4ea8"
+
 babel-messages@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
@@ -90,7 +102,7 @@ babel-runtime@^6.22.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-traverse@^6.15.0, babel-traverse@^6.23.1:
+babel-traverse@^6.15.0:
   version "6.23.1"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.23.1.tgz#d3cb59010ecd06a97d81310065f966b699e14f48"
   dependencies:
@@ -104,6 +116,27 @@ babel-traverse@^6.15.0, babel-traverse@^6.23.1:
     invariant "^2.2.0"
     lodash "^4.2.0"
 
+babel-traverse@^7.0.0-alpha.9:
+  version "7.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-7.0.0-alpha.9.tgz#749abf53c908ca80a8c96f5ca958d33732e0714f"
+  dependencies:
+    babel-code-frame "7.0.0-alpha.9"
+    babel-messages "7.0.0-alpha.9"
+    babel-types "7.0.0-alpha.9"
+    babylon "7.0.0-beta.8"
+    debug "^2.2.0"
+    globals "^9.0.0"
+    invariant "^2.2.0"
+    lodash "^4.2.0"
+
+babel-types@7.0.0-alpha.9, babel-types@^7.0.0-alpha.9:
+  version "7.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-7.0.0-alpha.9.tgz#45e48b93cecdd9d306ab6953d7819622a7c1462b"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.2.0"
+    to-fast-properties "^1.0.1"
+
 babel-types@^6.15.0, babel-types@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.23.0.tgz#bb17179d7538bad38cd0c9e115d340f77e7e9acf"
@@ -113,7 +146,11 @@ babel-types@^6.15.0, babel-types@^6.23.0:
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babylon@^6.13.0, babylon@^6.15.0, babylon@^6.16.1:
+babylon@7.0.0-beta.8, babylon@^7.0.0-alpha.9:
+  version "7.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.8.tgz#2bdc5ae366041442c27e068cce6f0d7c06ea9949"
+
+babylon@^6.13.0, babylon@^6.15.0:
   version "6.16.1"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.16.1.tgz#30c5a22f481978a9e7f8cdfdf496b11d94b404d3"
 


### PR DESCRIPTION
 - Node's with .properties may either have .value or .argument (in the
   case of rest element.

 - Update usage of is(Rest|Spread)Property as it now returns true for
   both the exact spread node and property node. (see https://github.com/babel/babel/blob/0eae6a432c344759b5869144d4f1bd0b4145cd05/packages/babel-traverse/src/path/lib/virtual-types.js#L124)