### PR TITLE
Fix flow type spread handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ function monkeypatch(modules) {
     // loops
     callProperties: { type: "loop", values: ["value"] },
     indexers: { type: "loop", values: ["key", "value"] },
-    properties: { type: "loop", values: ["value"] },
+    properties: { type: "loop", values: ["argument", "value"] },
     types: { type: "loop" },
     params: { type: "loop" },
     // single property
@@ -142,7 +142,10 @@ function monkeypatch(modules) {
         for (var j = 0; j < nodeProperty.length; j++) {
           if (Array.isArray(propertyType.values)) {
             for (var k = 0; k < propertyType.values.length; k++) {
-              checkIdentifierOrVisit.call(this, nodeProperty[j][propertyType.values[k]]);
+              var loopPropertyNode = nodeProperty[j][propertyType.values[k]];
+              if (loopPropertyNode) {
+                checkIdentifierOrVisit.call(this, loopPropertyNode);
+              }
             }
           } else {
             checkIdentifierOrVisit.call(this, nodeProperty[j]);

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "babel-code-frame": "^6.22.0",
     "babel-traverse": "^6.23.1",
     "babel-types": "^6.23.0",
-    "babylon": "^6.16.1"
+    "babylon": "^6.17.0"
   },
   "scripts": {
     "test": "npm run lint && npm run test-only",

--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -574,6 +574,18 @@ describe("verify", () => {
       );
     });
 
+    it("supports type spreading", () => {
+      verifyAndAssertMessages(
+        unpad(`
+          type U = {};
+          type T = {a: number, ...U, ...V};
+        `),
+        { "no-undef": 1, "no-unused-vars": 1 },
+        [ "2:6 'T' is defined but never used. no-unused-vars",
+          "2:31 'V' is not defined. no-undef" ]
+      );
+    });
+
     it("1", () => {
       verifyAndAssertMessages(
         unpad(`

--- a/yarn.lock
+++ b/yarn.lock
@@ -113,9 +113,9 @@ babel-types@^6.15.0, babel-types@^6.23.0:
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babylon@^6.13.0, babylon@^6.15.0, babylon@^6.16.1:
-  version "6.16.1"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.16.1.tgz#30c5a22f481978a9e7f8cdfdf496b11d94b404d3"
+babylon@^6.13.0, babylon@^6.15.0, babylon@^6.17.0:
+  version "6.17.0"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.0.tgz#37da948878488b9c4e3c4038893fa3314b3fc932"
 
 balanced-match@^0.4.1:
   version "0.4.2"


### PR DESCRIPTION
Support for this was just added to Babylon 6.17.0 (https://github.com/babel/babylon/pull/476). Unfortunately, without this fix, the use for type spreads crashes babel-eslint with:

```
     TypeError: Cannot read property 'typeAnnotation' of undefined
      at Referencer.checkIdentifierOrVisit (index.js:173:13)
      at Referencer.visitTypeAnnotation (index.js:148:38)
      at Referencer.referencer.TypeAlias (index.js:329:27)
      at Referencer.Visitor.visit (node_modules/esrecurse/esrecurse.js:122:34)
      at Referencer.Visitor.visitChildren (node_modules/esrecurse/esrecurse.js:101:38)
      at Referencer.Program (node_modules/escope/lib/referencer.js:419:18)
      at Referencer.Visitor.visit (node_modules/esrecurse/esrecurse.js:122:34)
      at Object.analyze (node_modules/escope/lib/index.js:153:16)
      at Object.escope.analyze (index.js:71:27)
      at EventEmitter.module.exports.api.verify (node_modules/eslint/lib/eslint.js:891:35)
```