### PR TITLE
Fix: Convert RegExpLieteral value to RegExp object (fixes #477)

### DIFF
--- a/babylon-to-espree/toAST.js
+++ b/babylon-to-espree/toAST.js
@@ -94,7 +94,11 @@ var astTransformVisitor = {
     if (path.isRegExpLiteral()) {
       node.type = "Literal";
       node.raw = node.extra.raw;
-      node.value = {};
+      try {
+        node.value = new RegExp(node.pattern, node.flags);
+      } catch (err) {
+        node.value = null;
+      }
       node.regex = {
         pattern: node.pattern,
         flags: node.flags

--- a/test/babel-eslint.js
+++ b/test/babel-eslint.js
@@ -20,6 +20,8 @@ function assertImplementsAST(target, source, path) {
   var typeB = source === null ? "null" : typeof source;
   if (typeA !== typeB) {
     error(`have different types (${typeA} !== ${typeB}) (${target} !== ${source})`);
+  } else if (typeA === "object" && ["RegExp"].indexOf(target.constructor.name) !== -1 && target.constructor.name !== source.constructor.name) {
+    error(`object have different constructors (${target.constructor.name} !== ${source.constructor.name}`);
   } else if (typeA === "object") {
     var keysTarget = Object.keys(target);
     for (var i in keysTarget) {
@@ -303,6 +305,18 @@ describe("babylon-to-esprima", () => {
 
   it("regexp", () => {
     parseAndAssertSame("/affix-top|affix-bottom|affix|[a-z]/");
+  });
+
+  it("regexp", () => {
+    parseAndAssertSame("const foo = /foo/;");
+  });
+
+  it("regexp y flag", () => {
+    parseAndAssertSame("const foo = /foo/y;");
+  });
+
+  it("regexp u flag", () => {
+    parseAndAssertSame("const foo = /foo/u;");
   });
 
   it("regexp in a template string", () => {


### PR DESCRIPTION
The only way I could get the tests to fail was to check the constructor name of both objects. I tried to match them for every object but many times they do not match.