### PR TITLE
Readme update usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,17 +43,17 @@ It just needs to export a `parse` method that takes in a string of code and outp
 
 ## Usage
 
-> ESLint 1.x | Use <= 5.x
-
-> ESLint 2.x | Use >= 6.x
-
 ### Supported ESLint versions
 
 ESLint | babel-eslint
 ------------ | -------------
 3.x | >= 6.x
+2.x | >= 6.x
+1.x | >= 5.x
 
 ### Install
+
+Ensure that you have substituted the correct version lock for `eslint` and `babel-eslint` into this command:
 
 ```sh
 $ npm install eslint@3.x babel-eslint@7 --save-dev

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Ensure that you have substituted the correct version lock for `eslint` and `babe
 
 ```sh
 $ npm install eslint@3.x babel-eslint@7 --save-dev
+# or
+$ yarn add eslint@3.x babel-eslint@y -D
 ```
 
 ### Setup

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Ensure that you have substituted the correct version lock for `eslint` and `babe
 ```sh
 $ npm install eslint@3.x babel-eslint@7 --save-dev
 # or
-$ yarn add eslint@3.x babel-eslint@y -D
+$ yarn add eslint@3.x babel-eslint@7 -D
 ```
 
 ### Setup


### PR DESCRIPTION
This PR updates the README Usage section. I hope that this helps.

The main update is basically a partial revert of 52b4a13. I found it a little hard to follow the README as a new user of `babel-eslint` that I had to view the version compatibilities between ESLint and babel-eslint in two separate spots of the document. I am unsure whether this PR will conflict with the intent of the commit's author, @hzoo, but hopefully my point of view can be of value to help the experience of new `babel-eslint` users.

I appreciate the feedback. Thank you.