### PR TITLE
Allow eslint to define the babylon plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -392,7 +392,7 @@ exports.parseNoPatch = function(code, options) {
     allowSuperOutsideMethod: true,
     ranges: true,
     tokens: true,
-    plugins: [
+    plugins: options.plugins || [
       "flow",
       "jsx",
       "estree",


### PR DESCRIPTION
If you want to use `babel-eslint`, currently that means opting into every syntax feature that babylon offers. This allows you to provide your own array of babylon plugins in the eslint `parserOptions`. For us, this will allow us to enable stage-3 syntax features, but still make things like do-expressions a syntax error. If you don't define plugins, it'll default to enabling them all.