### PR TITLE
Make 2018 the default ecmaVersion for rules relying on parserOptions

### DIFF
--- a/lib/analyze-scope.js
+++ b/lib/analyze-scope.js
@@ -318,7 +318,7 @@ module.exports = function(ast, parserOptions) {
           parserOptions.ecmaFeatures.globalReturn) === true,
     impliedStrict: false,
     sourceType: ast.sourceType,
-    ecmaVersion: parserOptions.ecmaVersion || 6,
+    ecmaVersion: parserOptions.ecmaVersion || 2018,
     fallback,
   };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ exports.parse = function(code, options) {
 
 exports.parseForESLint = function(code, options) {
   options = options || {};
-  options.ecmaVersion = options.ecmaVersion || 6;
+  options.ecmaVersion = options.ecmaVersion || 2018;
   options.sourceType = options.sourceType || "module";
   options.allowImportExportEverywhere =
     options.allowImportExportEverywhere || false;

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "eslint-plugin-flowtype": "^2.30.3",
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-prettier": "^2.1.2",
-    "espree": "^3.4.0",
+    "espree": "^3.5.2",
     "husky": "^0.14.0",
     "lint-staged": "^4.0.0",
     "mocha": "^4.0.0",

--- a/test/babel-eslint.js
+++ b/test/babel-eslint.js
@@ -37,7 +37,7 @@ function parseAndAssertSame(code) {
     range: true,
     comment: true,
     attachComment: true,
-    ecmaVersion: 8,
+    ecmaVersion: 2018,
     sourceType: "module",
   });
   var babylonAST = babelEslint.parseForESLint(code, {
@@ -71,7 +71,7 @@ function parseAndAssertSame(code) {
   // assert.equal(esAST, babylonAST);
 }
 
-describe("babylon-to-esprima", () => {
+describe("babylon-to-espree", () => {
   describe("compatibility", () => {
     it("should allow ast.analyze to be called without options", function() {
       var esAST = babelEslint.parseForESLint("`test`", {

--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -19,7 +19,7 @@ function verifyAndAssertMessagesWithSpecificESLint(
       es6: true,
     },
     parserOptions: {
-      ecmaVersion: 8,
+      ecmaVersion: 2018,
       ecmaFeatures: {
         jsx: true,
         experimentalObjectRestSpread: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -65,10 +65,6 @@ acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
-acorn@^5.0.1:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.0.3.tgz#c460df08491463f028ccb82eab3730bf01087b3d"
-
 acorn@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.2.1.tgz#317ac7821826c22c702d66189ab8359675f135d7"
@@ -598,13 +594,6 @@ eslint@^4.14.0:
     strip-json-comments "~2.0.1"
     table "^4.0.1"
     text-table "~0.2.0"
-
-espree@^3.4.0:
-  version "3.4.3"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-3.4.3.tgz#2910b5ccd49ce893c2ffffaab4fd8b3a31b82374"
-  dependencies:
-    acorn "^5.0.1"
-    acorn-jsx "^3.0.0"
 
 espree@^3.5.2:
   version "3.5.2"


### PR DESCRIPTION
Some core rules (and potentially custom rules in the ecosystem) rely on checking `parserOptions` in the rules themselves. Technically, since Babylon always parses the latest (including experimental) syntax, this should be set to the latest ESLint supports (currently 2018).