### PR TITLE
Re-add parseNoPatch function (accidentally removed)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,3 +15,7 @@ exports.parseForESLint = function(code, options) {
   patched = true;
   return { ast: require("./parse-with-patch")(code, options) };
 };
+
+exports.parseNoPatch = function(code, options) {
+  return require("./parse")(code, options);
+};

--- a/test/babel-eslint.js
+++ b/test/babel-eslint.js
@@ -531,3 +531,12 @@ describe("babylon-to-esprima", () => {
     });
   });
 });
+
+describe("Public API", () => {
+  it("exports a parseNoPatch function", () => {
+    assertImplementsAST(
+      espree.parse("foo"),
+      babelEslint.parseNoPatch("foo", {})
+    );
+  });
+});


### PR DESCRIPTION
dbc6546e0713a83c3362bb28d2d4604dbbebcf19 accidentally removed the `parseNoPatch` function from the public API. This commit adds it back.