### PR TITLE
Fix: ignore eval (fixes #560)

### DIFF
--- a/lib/analyze-scope.js
+++ b/lib/analyze-scope.js
@@ -309,6 +309,7 @@ class Referencer extends OriginalReferencer {
 
 module.exports = function(ast, parserOptions) {
   const options = {
+    ignoreEval: true,
     optimistic: false,
     directive: false,
     nodejsScope:

--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -1874,4 +1874,16 @@ describe("verify", () => {
       []
     );
   });
+
+  it("ignore eval in scope analysis", () => {
+    verifyAndAssertMessages(
+      unpad(`
+        const a = 1;
+        console.log(a);
+        eval('');
+      `),
+      { "no-unused-vars": 1, "no-undef": 1 },
+      []
+    );
+  });
 });


### PR DESCRIPTION
Fixes #560.
This PR added `ignoreEval` option to ignore `eval()` call.