### PR TITLE
Fix: add Literal type to visitorKeys

### DIFF
--- a/lib/parse-with-scope.js
+++ b/lib/parse-with-scope.js
@@ -1,13 +1,12 @@
 "use strict";
 
-const t = require("@babel/types");
+const visitorKeys = require("./visitor-keys");
 const analyzeScope = require("./analyze-scope");
 const parse = require("./parse");
 
 module.exports = function(code, options) {
   const ast = parse(code, options);
   const scopeManager = analyzeScope(ast, options);
-  const visitorKeys = t.VISITOR_KEYS;
 
   return { ast, scopeManager, visitorKeys };
 };

--- a/lib/visitor-keys.js
+++ b/lib/visitor-keys.js
@@ -5,6 +5,7 @@ const ESLINT_VISITOR_KEYS = require("eslint-visitor-keys").KEYS;
 
 module.exports = Object.assign(
   {
+    Literal: ESLINT_VISITOR_KEYS.Literal,
     MethodDefinition: ["decorators"].concat(
       ESLINT_VISITOR_KEYS.MethodDefinition
     ),


### PR DESCRIPTION
Refs https://github.com/babel/babel-eslint/issues/558#issuecomment-353861903.

Babel's AST did not have `Literal` type.
This PR adds it to improve performance.

~~Though I'm not sure why `Property` is unknown in that debug log... I confirmed it's `"Property": [ 'decorators', 'key', 'value' ]`.~~
