### PR TITLE
update babel packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     "url": "https://github.com/babel/babel-eslint.git"
   },
   "dependencies": {
-    "@babel/code-frame": "7.0.0-beta.31",
-    "@babel/traverse": "7.0.0-beta.31",
-    "@babel/types": "7.0.0-beta.31",
-    "babylon": "7.0.0-beta.31",
+    "@babel/code-frame": "7.0.0-beta.36",
+    "@babel/traverse": "7.0.0-beta.36",
+    "@babel/types": "7.0.0-beta.36",
+    "babylon": "7.0.0-beta.36",
     "eslint-scope": "~3.7.1",
     "eslint-visitor-keys": "^1.0.0"
   },

--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -1079,17 +1079,6 @@ describe("verify", () => {
       );
     });
 
-    it("42", () => {
-      verifyAndAssertMessages(
-        unpad(`
-          import type * as namespace from 'bar';
-          namespace;
-        `),
-        { "no-unused-vars": 1, "no-undef": 1 },
-        []
-      );
-    });
-
     it("43", () => {
       verifyAndAssertMessages(
         unpad(`


### PR DESCRIPTION
There is some critical bug fixes in version babylon#7.0.0-beta.33 regard `async` - `await` syntax which is needed pretty immediately :)
 
also removing one test as `import type *` is invalid, since the namespace can't be a type, and it is shown as an error now.