### PR TITLE
Fix: wrong token type of ! and ~ (fixes #576)

### DIFF
--- a/lib/babylon-to-espree/toToken.js
+++ b/lib/babylon-to-espree/toToken.js
@@ -38,7 +38,8 @@ module.exports = function(token, tt, source) {
     type === tt.plusMin ||
     type === tt.modulo ||
     type === tt.exponent ||
-    type === tt.prefix ||
+    type === tt.bang ||
+    type === tt.tilde ||
     type === tt.doubleColon ||
     type.isAssign
   ) {

--- a/test/babel-eslint.js
+++ b/test/babel-eslint.js
@@ -48,12 +48,6 @@ function parseAndAssertSame(code) {
     assertImplementsAST(esAST, babylonAST);
   } catch (err) {
     var traversal = err.message.slice(3, err.message.indexOf(":"));
-    if (esAST.tokens) {
-      delete esAST.tokens;
-    }
-    if (babylonAST.tokens) {
-      delete babylonAST.tokens;
-    }
     err.message += unpad(`
       espree:
       ${util.inspect(lookup(esAST, traversal, 2), {
@@ -168,6 +162,14 @@ describe("babylon-to-espree", () => {
 
   it("simple expression", () => {
     parseAndAssertSame("a = 1");
+  });
+
+  it("logical NOT", () => {
+    parseAndAssertSame("!0");
+  });
+
+  it("bitwise NOT", () => {
+    parseAndAssertSame("~0");
   });
 
   it("class declaration", () => {


### PR DESCRIPTION
Fixes #576.

This PR fixes a bug of token types.

~~The token type of bitwise/logical NOT should be `tt.prefix`, but the `tt.prefix` does not match to bitwise/logical NOT in the current Babylon parser. This PR adds a workaround.~~

EDIT: Babylon does not have `tt.prefix`. It has `tt.bang` and `tt.tilde` instead.