### PR TITLE
Support cyclic type declarations (#485)

### DIFF
--- a/lib/babylon-to-espree/toAST.js
+++ b/lib/babylon-to-espree/toAST.js
@@ -72,6 +72,15 @@ var astTransformVisitor = {
       delete node.bound;
     }
 
+    if (path.isTypeAlias()) {
+      node.type = "FunctionDeclaration";
+      node.generator = false;
+      node.async = false;
+      node.expression = false;
+      node.params = [];
+      node.body = node.right;
+    }
+
     // flow: prevent "no-undef"
     // for "Component" in: "let x: React.Component"
     if (path.isQualifiedTypeIdentifier()) {

--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -1157,6 +1157,18 @@ describe("verify", () => {
         []
       );
     });
+
+    it("cyclic type dependencies #485", () => {
+      verifyAndAssertMessages(
+        unpad(`
+          type Node<T> = { head: T, tail: Node<T> };
+          type A = B[];
+          type B = number;
+        `),
+        { "no-use-before-define": 1 },
+        []
+      );
+    });
   });
 
   it("class usage", () => {


### PR DESCRIPTION
Using a type before its definition shouldn't trigger a no-use-before-define warning. Flow types should experience them same behavior as function declarations (they behave currently more like function expressions).

Cyclic type dependencies are common when using flow.
For instance: 
```
type Node<T> = { head: T; tail: Node<T> }
```

Fixes #485