### PR TITLE
Save babel beta packages as exact versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     "url": "https://github.com/babel/babel-eslint.git"
   },
   "dependencies": {
-    "@babel/code-frame": "^7.0.0-beta.40",
-    "@babel/traverse": "^7.0.0-beta.40",
-    "@babel/types": "^7.0.0-beta.40",
-    "babylon": "^7.0.0-beta.40",
+    "@babel/code-frame": "7.0.0-beta.40",
+    "@babel/traverse": "7.0.0-beta.40",
+    "@babel/types": "7.0.0-beta.40",
+    "babylon": "7.0.0-beta.40",
     "eslint-scope": "~3.7.1",
     "eslint-visitor-keys": "^1.0.0"
   },


### PR DESCRIPTION
As we saw in babel/babel#7654, beta packages should be saved as exact versions, since changes can potentially contain serious bugs. In particular, `@babel/traverse@7.0.0-beta.43` crashed every single node 6 CI in the world today.

Also related: #605 