### PR TITLE
updates readme for latest eslint & babel-eslint

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ It just needs to export a `parse` method that takes in a string of code and outp
 
 ESLint | babel-eslint
 ------------ | -------------
+4.x | >= 6.x
 3.x | >= 6.x
 2.x | >= 6.x
 1.x | >= 5.x
@@ -56,9 +57,9 @@ ESLint | babel-eslint
 Ensure that you have substituted the correct version lock for `eslint` and `babel-eslint` into this command:
 
 ```sh
-$ npm install eslint@3.x babel-eslint@7 --save-dev
+$ npm install eslint@4.x babel-eslint@8 --save-dev
 # or
-$ yarn add eslint@3.x babel-eslint@7 -D
+$ yarn add eslint@4.x babel-eslint@8 -D
 ```
 
 ### Setup


### PR DESCRIPTION
while i'm not 100% confident that the version range (`>=6.x`) is correct for compatibility with the latest versions of ESLint, it was def missing and unclear whether ESLint v4.x was supported. anecdotally, these versions work for me. also the installation instructions were referencing older versions of these packages (IMHO they don't need to reference any version at all, but i chose to stay with the convention).