### PR TITLE
Add test for template string with object with template string inside

### DIFF
--- a/test/babel-eslint.js
+++ b/test/babel-eslint.js
@@ -166,6 +166,10 @@ describe("babylon-to-espree", () => {
         }}\`;
       `);
     });
+
+    it("template string with object with template string inside", () => {
+      parseAndAssertSame("`${ { a:`${2}` } }`");
+    });
   });
 
   it("simple expression", () => {


### PR DESCRIPTION
Closes https://github.com/babel/babel-eslint/pull/538.
Fixes https://github.com/babel/babel-eslint/issues/537.

Now that https://github.com/babel/babel-eslint/pull/610 has landed, I wanted to make sure this case was covered.