### PR TITLE
Docs: Make the default parserOptions more explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ Check out the [ESLint docs](http://eslint.org/docs/rules/) for all possible rule
 
 ### Configuration
 
-`sourceType` can be set to `'module'`(default) or `'script'` if your code isn't using ECMAScript modules.
-`allowImportExportEverywhere` can be set to true to allow import and export declarations to appear anywhere a statement is allowed if your build environment supports that. By default, import and export declarations can only appear at a program's top level.
-`codeFrame` can be set to false to disable the code frame in the reporter. This is useful since some eslint formatters don't play well with it.
+- `sourceType` can be set to `'module'`(default) or `'script'` if your code isn't using ECMAScript modules.
+- `allowImportExportEverywhere` (default `false`) can be set to `true` to allow import and export declarations to appear anywhere a statement is allowed if your build environment supports that. Otherwise import and export declarations can only appear at a program's top level.
+- `codeFrame` (default `true`) can be set to `false` to disable the code frame in the reporter. This is useful since some eslint formatters don't play well with it.
 
 **.eslintrc**
 
@@ -91,7 +91,7 @@ Check out the [ESLint docs](http://eslint.org/docs/rules/) for all possible rule
   "parserOptions": {
     "sourceType": "module",
     "allowImportExportEverywhere": false,
-    "codeFrame": false
+    "codeFrame": true
   }
 }
 ```


### PR DESCRIPTION
In particular, previously the `.eslintrc` example implied that the default value for `codeFrame` was `false`, when in fact it is `true`:
https://github.com/babel/babel-eslint/blob/v9.0.0-beta.3/lib/parse.js#L14