### PR TITLE
:heavy_plus_sign: Added `estraverse` dependency

### DIFF
--- a/lib/patch-eslint-scope.js
+++ b/lib/patch-eslint-scope.js
@@ -3,6 +3,7 @@
 var Module = require("module");
 var path = require("path");
 var t = require("@babel/types");
+var estraverse = require("estraverse");
 
 function getModules() {
   try {
@@ -33,14 +34,11 @@ function getModules() {
     referencer = eslintMod.require("escope/lib/referencer");
   }
 
-  var estraverse = eslintMod.require("estraverse");
-
   if (referencer.__esModule) referencer = referencer.default;
 
   return {
     Definition,
     escope,
-    estraverse,
     referencer,
   };
 }
@@ -48,7 +46,6 @@ function getModules() {
 function monkeypatch(modules) {
   var Definition = modules.Definition;
   var escope = modules.escope;
-  var estraverse = modules.estraverse;
   var referencer = modules.referencer;
 
   Object.assign(estraverse.VisitorKeys, t.VISITOR_KEYS);

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "@babel/traverse": "^7.0.0",
     "@babel/types": "^7.0.0",
     "eslint-scope": "3.7.1",
-    "eslint-visitor-keys": "^1.0.0"
+    "eslint-visitor-keys": "^1.0.0",
+    "estraverse": "^4.2.0"
   },
   "scripts": {
     "test": "npm run lint && npm run test-only",


### PR DESCRIPTION
Hi everyone,

I propose this PR in order to solve a problem related to `estraverse` dependency which is used in `./lib/patch-eslint-scope.js`. Currently `babel-eslint` import this dependency from eslintMod (allows to import the module of `eslint`) except this is a problem because `estraverse` isn't a dependency used by `eslint`. This produce an error when we use the package manager `pnpm` for example.

To solve this problem, we install `estraverse` in the dependencies and modify "patch-eslint-scope.js" to use it.

Current issue opened : Incorrect estraverse require #680 