### PR TITLE
Add support for customizing parser plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ Please check out [eslint-plugin-react](https://github.com/yannickcr/eslint-plugi
 
 Please check out [eslint-plugin-babel](https://github.com/babel/eslint-plugin-babel) for other issues
 
+TypeScript:
+> These issues is related to [eslint-plugin-typescript](https://github.com/nzakas/eslint-plugin-typescript).
+- `typescript/no-namespace`: Babel doesn't support TypeScript's namesapce.
+- `typescript/prefer-namespace-keyword`: Babel doesn't support TypeScript's namesapce.
+
 ## How does it work?
 
 ESLint allows custom parsers. This is great but some of the syntax nodes that Babel supports

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ### Why Use babel-eslint
 
-You only need to use babel-eslint if you are using types (Flow) or experimental features not supported in ESLint itself yet. Otherwise try the default parser (you don't have to use it just because you are using Babel).
+You only need to use babel-eslint if you are using types (Flow or TypeScript) or experimental features not supported in ESLint itself yet. Otherwise try the default parser (you don't have to use it just because you are using Babel).
 
 ---
 
@@ -82,6 +82,8 @@ Check out the [ESLint docs](http://eslint.org/docs/rules/) for all possible rule
 - `sourceType` can be set to `'module'`(default) or `'script'` if your code isn't using ECMAScript modules.
 - `allowImportExportEverywhere` (default `false`) can be set to `true` to allow import and export declarations to appear anywhere a statement is allowed if your build environment supports that. Otherwise import and export declarations can only appear at a program's top level.
 - `codeFrame` (default `true`) can be set to `false` to disable the code frame in the reporter. This is useful since some eslint formatters don't play well with it.
+- `plugins` is an array which let you add more babel parser syntax plugins. Note that most of plugins are enabled by default, so you don't need to add something explicitly. You can enable `typescript` plugin via this option, and the `flow` plugin will be disabled automatically.
+- `excludePlugins` is an array which let you disable some plugins. One possible use case is that you don't want to use one experimental ECMAScript feature accidently. Note that you don't need to disable `flow` plugin if you have enabled `typescript` plugin.
 
 **.eslintrc**
 
@@ -91,7 +93,13 @@ Check out the [ESLint docs](http://eslint.org/docs/rules/) for all possible rule
   "parserOptions": {
     "sourceType": "module",
     "allowImportExportEverywhere": false,
-    "codeFrame": true
+    "codeFrame": true,
+    "plugins": [
+      "typescript"
+    ],
+    "exclude": [
+      "bigInt"
+    ]
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Please check out [eslint-plugin-react](https://github.com/yannickcr/eslint-plugi
 Please check out [eslint-plugin-babel](https://github.com/babel/eslint-plugin-babel) for other issues
 
 TypeScript:
-> These issues is related to [eslint-plugin-typescript](https://github.com/nzakas/eslint-plugin-typescript).
+> These issues are related to [eslint-plugin-typescript](https://github.com/nzakas/eslint-plugin-typescript).
 - `typescript/no-namespace`: Babel doesn't support TypeScript's namesapce.
 - `typescript/prefer-namespace-keyword`: Babel doesn't support TypeScript's namesapce.
 
@@ -88,7 +88,7 @@ Check out the [ESLint docs](http://eslint.org/docs/rules/) for all possible rule
 - `allowImportExportEverywhere` (default `false`) can be set to `true` to allow import and export declarations to appear anywhere a statement is allowed if your build environment supports that. Otherwise import and export declarations can only appear at a program's top level.
 - `codeFrame` (default `true`) can be set to `false` to disable the code frame in the reporter. This is useful since some eslint formatters don't play well with it.
 - `plugins` is an array which let you add more babel parser syntax plugins. Note that most of plugins are enabled by default, so you don't need to add something explicitly. You can enable `typescript` plugin via this option, and the `flow` plugin will be disabled automatically.
-- `excludePlugins` is an array which let you disable some plugins. One possible use case is that you don't want to use one experimental ECMAScript feature accidently. Note that you don't need to disable `flow` plugin if you have enabled `typescript` plugin.
+- `excludePlugins` is an array which let you disable some plugins. One possible use case is that you don't want to use one experimental ECMAScript feature accidentally. Note that you don't need to disable `flow` plugin if you have enabled `typescript` plugin.
 
 **.eslintrc**
 

--- a/lib/babylon-to-espree/toAST.js
+++ b/lib/babylon-to-espree/toAST.js
@@ -123,5 +123,17 @@ var astTransformVisitor = {
         }
       }
     }
+
+    // TypeScript
+    if (path.isTSInterfaceDeclaration()) {
+      node.heritage = node.extends || [];
+    }
+
+    if (path.isTSTypeAssertion()) {
+      node.type = "TSTypeAssertionExpression";
+      node.loc.start.column--;
+      const typeAnnotation = Object.assign({}, node.typeAnnotation);
+      node.typeAnnotation.typeAnnotation = typeAnnotation;
+    }
   },
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,12 +4,10 @@ exports.parse = function(code, options) {
   return exports.parseForESLint(code, options).ast;
 };
 
-exports.parseForESLint = function(code, options) {
-  options = options || {};
+exports.parseForESLint = function(code, options = {}) {
   options.ecmaVersion = options.ecmaVersion || 2018;
   options.sourceType = options.sourceType || "module";
-  options.allowImportExportEverywhere =
-    options.allowImportExportEverywhere || false;
+  options.allowImportExportEverywhere = !!options.allowImportExportEverywhere;
 
   return require("./parse-with-scope")(code, options);
 };

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var babylonToEspree = require("./babylon-to-espree");
-var parse = require("@babel/parser").parse;
+var parser = require("@babel/parser");
 var tt = require("@babel/parser").tokTypes;
 var traverse = require("@babel/traverse").default;
 var codeFrameColumns = require("@babel/code-frame").codeFrameColumns;
@@ -57,8 +57,7 @@ module.exports = function(code, options) {
   options.excludePlugins = options.excludePlugins || [];
   options.excludePlugins.forEach(plugin => {
     opts.plugins = opts.plugins.filter(p => {
-      const type = typeof p;
-      if (type === "string") {
+      if (typeof p === "string") {
         return p !== plugin;
       } else {
         return p[0] !== plugin;
@@ -68,7 +67,7 @@ module.exports = function(code, options) {
 
   var ast;
   try {
-    ast = parse(code, opts);
+    ast = parser.parse(code, opts);
   } catch (err) {
     if (err instanceof SyntaxError) {
       err.lineNumber = err.loc.line;

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -22,9 +22,9 @@ module.exports = function(code, options) {
     ranges: true,
     tokens: true,
     plugins: [
+      "estree",
       isTS ? "typescript" : ["flow", { all: true }],
       "jsx",
-      "estree",
       "asyncFunctions",
       "asyncGenerators",
       "classConstructorCall",
@@ -55,9 +55,6 @@ module.exports = function(code, options) {
   };
 
   options.excludePlugins = options.excludePlugins || [];
-  if (isTS) {
-    options.excludePlugins.push("estree"); // The estree plugin has conflicts with TS
-  }
   options.excludePlugins.forEach(plugin => {
     opts.plugins = opts.plugins.filter(p => {
       if (typeof p === "string") {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -10,6 +10,9 @@ module.exports = function(code, options) {
   const legacyDecorators =
     options.ecmaFeatures && options.ecmaFeatures.legacyDecorators;
 
+  options.plugins = options.plugins || [];
+  const isTS = options.plugins.includes("typescript");
+
   var opts = {
     codeFrame: options.hasOwnProperty("codeFrame") ? options.codeFrame : true,
     sourceType: options.sourceType,
@@ -19,7 +22,7 @@ module.exports = function(code, options) {
     ranges: true,
     tokens: true,
     plugins: [
-      ["flow", { all: true }],
+      isTS ? "typescript" : ["flow", { all: true }],
       "jsx",
       "estree",
       "asyncFunctions",
@@ -50,6 +53,18 @@ module.exports = function(code, options) {
       "logicalAssignment",
     ],
   };
+
+  options.excludePlugins = options.excludePlugins || [];
+  options.excludePlugins.forEach(plugin => {
+    opts.plugins = opts.plugins.filter(p => {
+      const type = typeof p;
+      if (type === "string") {
+        return p !== plugin;
+      } else {
+        return p[0] !== plugin;
+      }
+    });
+  });
 
   var ast;
   try {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -55,6 +55,9 @@ module.exports = function(code, options) {
   };
 
   options.excludePlugins = options.excludePlugins || [];
+  if (isTS) {
+    options.excludePlugins.push("estree"); // The estree plugin has conflicts with TS
+  }
   options.excludePlugins.forEach(plugin => {
     opts.plugins = opts.plugins.filter(p => {
       if (typeof p === "string") {

--- a/test/customize-plugins.js
+++ b/test/customize-plugins.js
@@ -1,0 +1,41 @@
+const assert = require("assert");
+const CLIEngine = require("eslint").CLIEngine;
+
+describe("support customizing plugins via parser options", () => {
+  it("remove flow if typescript is existed", () => {
+    const code = "function fn(arg: ?number) {}";
+    const cli = new CLIEngine({
+      parser: require.resolve("../lib"),
+      parserOptions: {
+        plugins: ["typescript"],
+      },
+      useEslintrc: false,
+    });
+
+    const report = cli.executeOnText(code);
+    assert.strictEqual(report.errorCount, 1);
+    assert.ok(
+      report.results[0].messages[0].message.includes("Unexpected token")
+    );
+  });
+
+  it("support excluding specific plugins", () => {
+    const cli = new CLIEngine({
+      parser: require.resolve("../lib"),
+      parserOptions: {
+        excludePlugins: ["flow", "dynamicImport"],
+      },
+      useEslintrc: false,
+    });
+
+    let report = cli.executeOnText("function fn(arg: ?number) {}");
+    assert.strictEqual(report.errorCount, 1);
+    assert.ok(
+      report.results[0].messages[0].message.includes("Unexpected token")
+    );
+
+    report = cli.executeOnText('import(".")');
+    assert.strictEqual(report.errorCount, 1);
+    assert.ok(report.results[0].messages[0].message.includes("experimental"));
+  });
+});


### PR DESCRIPTION
Maybe partially fix #505 .

This PR enables a feature that user can enable or disable babel parser plugins via `parserOptions` in `.eslintrc` file. This can let us parse TypeScript code with babel.

**If anyone can't wait this PR, you can try: https://github.com/g-plane/pluggable-babel-eslint**