### PR TITLE
Add support for opaque types in scope analysis

### DIFF
--- a/lib/analyze-scope.js
+++ b/lib/analyze-scope.js
@@ -157,6 +157,18 @@ class Referencer extends OriginalReferencer {
     }
   }
 
+  OpaqueType(node) {
+    this._createScopeVariable(node, node.id);
+
+    const typeParamScope = this._nestTypeParamScope(node);
+
+    this.visit(node.impltype);
+
+    if (typeParamScope) {
+      this.close(node);
+    }
+  }
+
   ClassProperty(node) {
     this._visitClassProperty(node);
   }


### PR DESCRIPTION
Opaque type is virtually the same as type alias from syntax point of view, so I just copied the code for TypeAlias visitor and changed `right` to `impltype`.