### PR TITLE
Revert 584

### DIFF
--- a/lib/babylon-to-espree/toAST.js
+++ b/lib/babylon-to-espree/toAST.js
@@ -72,15 +72,6 @@ var astTransformVisitor = {
       delete node.bound;
     }
 
-    if (path.isTypeAlias()) {
-      node.type = "FunctionDeclaration";
-      node.generator = false;
-      node.async = false;
-      node.expression = false;
-      node.params = [];
-      node.body = node.right;
-    }
-
     // flow: prevent "no-undef"
     // for "Component" in: "let x: React.Component"
     if (path.isQualifiedTypeIdentifier()) {

--- a/test/non-regression.js
+++ b/test/non-regression.js
@@ -1091,18 +1091,6 @@ describe("verify", () => {
         { "no-unused-vars": 1, "no-undef": 1 }
       );
     });
-
-    it("cyclic type dependencies #485", () => {
-      verifyAndAssertMessages(
-        unpad(`
-          type Node<T> = { head: T, tail: Node<T> };
-          type A = B[];
-          type B = number;
-        `),
-        { "no-use-before-define": 1 },
-        []
-      );
-    });
   });
 
   it("class usage", () => {


### PR DESCRIPTION
Fixes #691
Reverts #584

We'll need to figure out a better approach than converting a `TypeAlias` into a Function Declaration. I guess it kind of made sense because I assume the reason for the original issue is that you are using it before define (and for functions they are hoisted and it's ok to use them before defined). So we need to make a decision on if we want these TypeAlias to act like functions.

Will need to re-open https://github.com/babel/babel-eslint/issues/485 then.