### PR TITLE
Test Node v11 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: node_js
 node_js:
+  - "11"
   - "10"
   - "8"
   - "6"


### PR DESCRIPTION
Now that Node v11 is officially in development, we should probably start testing it.