### PR TITLE
Major: remove parseNoPatch

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,3 @@ exports.parseForESLint = function(code, options) {
 
   return require("./parse-with-scope")(code, options);
 };
-
-exports.parseNoPatch = function(code, options) {
-  return require("./parse")(code, options);
-};

--- a/test/babel-eslint.js
+++ b/test/babel-eslint.js
@@ -536,12 +536,3 @@ describe("babylon-to-espree", () => {
     });
   });
 });
-
-describe("Public API", () => {
-  it("exports a parseNoPatch function", () => {
-    assertImplementsAST(
-      espree.parse("foo"),
-      babelEslint.parseNoPatch("foo", {})
-    );
-  });
-});


### PR DESCRIPTION
This API is no longer used! As pointed out by @existentialism, it was originally used post-monkeypatching (or if it was already patched): https://github.com/babel/babel-eslint/blame/945f00a2e03b5a4cf2967b2cc0fa20dfc9856192/index.js#L381.