### PR TITLE
forward allowAwaitOutsideFunction options to babel

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -28,6 +28,7 @@ module.exports = function(code, options) {
     ignore: options.babelOptions.ignore,
     only: options.babelOptions.only,
     parserOpts: {
+      allowAwaitOutsideFunction: options.allowAwaitOutsideFunction,
       allowImportExportEverywhere: options.allowImportExportEverywhere, // consistent with espree
       allowReturnOutsideFunction: true,
       allowSuperOutsideMethod: true,


### PR DESCRIPTION
**Before this pr**
It seems there is no way to configure `babel-eslint` to allow top level await.

**After this pr**
One could write this inside `.eslintrc.js`
```js
module.exports = {
  parser: "babel-eslint",
  parserOptions: {
    allowAwaitOutsideFunction: true
  }
}
```
