### PR TITLE
Docs: Add glob-based configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ This configuration would use the default parser for all files except for those f
 ```js
 module.exports = {
   rules: {
-    indent: 'error'
+    indent: "error"
   },
   overrides: [
     {


### PR DESCRIPTION
As discussed [here](https://github.com/babel/babel-eslint/pull/743#discussion_r249234258), this adds an example for how to use the recommended `overrides` method for using `babel-eslint` on compiled files only.