### PR TITLE
Fix `no-undef` for several cases

### DIFF
--- a/lib/analyze-scope.js
+++ b/lib/analyze-scope.js
@@ -177,6 +177,14 @@ class Referencer extends OriginalReferencer {
     this._visitDeclareX(node);
   }
 
+  DeclareTypeAlias(node) {
+    this._visitDeclareX(node);
+  }
+
+  DeclareInterface(node) {
+    this._visitDeclareX(node);
+  }
+
   // visit OptionalMemberExpression as a MemberExpression.
   OptionalMemberExpression(node) {
     super.MemberExpression(node);

--- a/lib/analyze-scope.js
+++ b/lib/analyze-scope.js
@@ -296,8 +296,16 @@ class Referencer extends OriginalReferencer {
       } else if (propertyType.type === "typeAnnotation") {
         this._visitTypeAnnotation(node.typeAnnotation);
       } else if (propertyType.type === "typeParameters") {
-        for (let l = 0; l < node.typeParameters.params.length; l++) {
-          this._checkIdentifierOrVisit(node.typeParameters.params[l]);
+        // Property typeParameters of FunctionTypeAnnotation represents type parameters list of such function.
+        // In all other cases, it is a list of concrete type usages (as in `var foo: Foo<T>`).
+        // The difference is that in function case, they should be treated as variable declarations,
+        // whereas in other cases as variable references.
+        if (node.type === "FunctionTypeAnnotation") {
+          this._nestTypeParamScope(node);
+        } else {
+          for (let l = 0; l < node.typeParameters.params.length; l++) {
+            this._checkIdentifierOrVisit(node.typeParameters.params[l]);
+          }
         }
       } else if (propertyType.type === "id") {
         if (node.id.type === "Identifier") {

--- a/lib/analyze-scope.js
+++ b/lib/analyze-scope.js
@@ -146,15 +146,11 @@ class Referencer extends OriginalReferencer {
   }
 
   TypeAlias(node) {
-    this._createScopeVariable(node, node.id);
+    this._visitTypeAlias(node, "right");
+  }
 
-    const typeParamScope = this._nestTypeParamScope(node);
-
-    this.visit(node.right);
-
-    if (typeParamScope) {
-      this.close(node);
-    }
+  OpaqueType(node) {
+    this._visitTypeAlias(node, "impltype");
   }
 
   ClassProperty(node) {
@@ -189,6 +185,18 @@ class Referencer extends OriginalReferencer {
   _visitClassProperty(node) {
     this._visitTypeAnnotation(node.typeAnnotation);
     this.visitProperty(node);
+  }
+
+  _visitTypeAlias(node, rightProperty) {
+    this._createScopeVariable(node, node.id);
+
+    const typeParamScope = this._nestTypeParamScope(node);
+
+    this.visit(node[rightProperty]);
+
+    if (typeParamScope) {
+      this.close(node);
+    }
   }
 
   _visitDeclareX(node) {

--- a/test/specs/non-regression.js
+++ b/test/specs/non-regression.js
@@ -1089,6 +1089,15 @@ describe("verify", () => {
         { "no-unused-vars": 1, "no-undef": 1 }
       );
     });
+
+    it("opaque type aliases", () => {
+      verifyAndAssertMessages(
+        `
+          opaque type Foo = number;
+        `,
+        { "no-undef": 1 }
+      );
+    });
   });
 
   it("class usage", () => {

--- a/test/specs/non-regression.js
+++ b/test/specs/non-regression.js
@@ -573,14 +573,16 @@ describe("verify", () => {
       );
     });
 
-    it("support declarations #132", () => {
+    it("support declarations #132, #625", () => {
       verifyAndAssertMessages(
         `
           declare class A { static () : number }
           declare module B { declare var x: number; }
           declare function foo<T>(): void;
-          declare var bar
-          A; B; foo(); bar;
+          declare var bar;
+          declare type Foo = number;
+          declare interface IFoo {}
+          A; B; foo<Foo>(); bar; class FooImpl implements IFoo {}; new FooImpl();
         `,
         { "no-undef": 1, "no-unused-vars": 1 }
       );

--- a/test/specs/non-regression.js
+++ b/test/specs/non-regression.js
@@ -815,10 +815,9 @@ describe("verify", () => {
     it("22", () => {
       verifyAndAssertMessages(
         `
-          import type Foo from 'foo';
+          import type Foo1 from 'foo';
           import type Foo2 from 'foo';
-          import type Foo3 from 'foo';
-          var a: { id<Foo>(x: Foo2): Foo3; }; a;
+          var a: { id(x: Foo1): Foo2; }; a;
         `,
         { "no-unused-vars": 1, "no-undef": 1 }
       );
@@ -970,11 +969,10 @@ describe("verify", () => {
     it("37", () => {
       verifyAndAssertMessages(
         `
-          import type Foo from 'foo';
+          import type Foo1 from 'foo';
           import type Foo2 from 'foo';
           import type Foo3 from 'foo';
-          import type Foo4 from 'foo';
-          var a: <Foo>(x: Foo2, ...y:Foo3[]) => Foo4; a;
+          var a: (x: Foo1, ...y: Foo2[]) => Foo3; a;
         `,
         { "no-unused-vars": 1, "no-undef": 1 }
       );
@@ -1096,6 +1094,17 @@ describe("verify", () => {
       verifyAndAssertMessages(
         `
           opaque type Foo = number;
+        `,
+        { "no-undef": 1 }
+      );
+    });
+
+    it("generic function annotations", () => {
+      verifyAndAssertMessages(
+        `
+          var foo: <T>(x: T) => T;
+          type Foo = { foo<T>(x: T): T };
+          type Bar = { foo: <T>(x: T) => T };
         `,
         { "no-undef": 1 }
       );


### PR DESCRIPTION
This PR deals with #625. It fixes three things (implementations are split into separate commits for convenient review):

* opaque type aliases (related PR is #696)
* `declare type = ...` and `declare interface Foo {}` which were missing
* generic parameters for function type annotations

One thing I am not sure about is [this part](https://github.com/babel/babel-eslint/compare/master...pnevyk:missing-type-visitors?expand=1#diff-3ab10361493aeb949966224850773473R299). The root cause of function generics misbehavior was that `_visitTypeAnnotation` was treating type parameters of function type annotation as variable references instead of variable declarations. But I am not sure if this is the best fix, especially whether `_nestTypeParamScope` is used correctly.

I must have change some tests which were imho incorrect ([1](https://github.com/babel/babel-eslint/compare/master...pnevyk:missing-type-visitors?expand=1#diff-4acaf9ae6b90e1b76c40ecff6d815fe0L813), [2](https://github.com/babel/babel-eslint/compare/master...pnevyk:missing-type-visitors?expand=1#diff-4acaf9ae6b90e1b76c40ecff6d815fe0L968)).

---

I would like to tackle the other half of #625 issue as well, either in this PR or in a separate one. But I want to be sure that my reasoning is correct:

In my opinion, `declare ...` statements should not emit `no-unused-vars` regardless if they are referenced in the file or not, since they serve as library definitions (ie. typed interface with outside world for code without Flow types in sources). Therefore I propose to reference these declarations automatically.

---

Also, I think that [this known issue](https://github.com/babel/babel-eslint/blame/35a64b2faecc726d8b7f62b99a5d37c971fe3fa3/README.md#L112) can be removed from the README, as it is not issue anymore for some time already.