### PR TITLE
Fix to convert hash token.

### DIFF
--- a/lib/babylon-to-espree/convertToken.js
+++ b/lib/babylon-to-espree/convertToken.js
@@ -44,6 +44,7 @@ module.exports = function(token, tt, source) {
     type === tt.bang ||
     type === tt.tilde ||
     type === tt.doubleColon ||
+    type === tt.hash ||
     type.isAssign
   ) {
     token.type = "Punctuator";

--- a/test/specs/babel-eslint.js
+++ b/test/specs/babel-eslint.js
@@ -267,6 +267,17 @@ describe("babylon-to-espree", () => {
     assert.strictEqual(babylonAST.tokens[1].type, "Punctuator");
   });
 
+  // Espree doesn't support the private fields yet
+  it("hash (token)", () => {
+    const code = "class A { #x }";
+    const babylonAST = babelEslint.parseForESLint(code, {
+      eslintVisitorKeys: true,
+      eslintScopeManager: true,
+    }).ast;
+    assert.strictEqual(babylonAST.tokens[3].type, "Punctuator");
+    assert.strictEqual(babylonAST.tokens[3].value, "#");
+  });
+
   it.skip("empty program with line comment", () => {
     parseAndAssertSame("// single comment");
   });


### PR DESCRIPTION
Fixed #752 

This pull request makes the hash token of the class private field to be converted to the token specification of ESLint.