### PR TITLE
Add failing test for `classPrivateMethods` (regression)

### DIFF
--- a/test/specs/non-regression.js
+++ b/test/specs/non-regression.js
@@ -1830,6 +1830,14 @@ describe("verify", () => {
     );
   });
 
+  it("works with classPrivateMethods", () => {
+    verifyAndAssertMessages(
+      `
+        class A { #c() {} }
+      `
+    );
+  });
+
   it("works with optionalCatchBinding", () => {
     verifyAndAssertMessages(
       `


### PR DESCRIPTION
Hi, I read this PR https://github.com/babel/babel-eslint/pull/729 and this issue https://github.com/babel/babel-eslint/issues/728 and it seems like `classPrivateMethods` should work. However, it doesn't. So I added a failing test since I don't know how to fix it.

Thank you very much for checking it.