### PR TITLE
Flow: add failing test for internal slot properties

### DIFF
--- a/test/specs/non-regression.js
+++ b/test/specs/non-regression.js
@@ -1089,6 +1089,19 @@ describe("verify", () => {
         { "no-unused-vars": 1, "no-undef": 1 }
       );
     });
+
+    it("parses internal slot", () => {
+      verifyAndAssertMessages(
+        `
+          type F = {
+            (): string,
+            (x: boolean): string,
+            [[call]](x: number): string,
+            [[call]]: string => string,
+          };
+        `
+      );
+    });
   });
 
   it("class usage", () => {


### PR DESCRIPTION
Hello, seems like Babel itself doesn't have any problem with Flow internal slot properties ([see repl](https://babeljs.io/en/repl#?babili=false&browsers=&build=&builtIns=false&spec=true&loose=false&code_lz=C4TwDgpgBAYlC8UDeAoKUAUBKAXFAzsAE4CWAdgOYA0amAHngEYD2zANhAIZm4HHnVaAbSEBjTmzYBdKRgZQyAVwC2jCEV6FSlGuhHjJMvFoEIAfH22CAvgG4UQA&debug=true&forceAllTransforms=true&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=false&presets=flow&prettier=false&targets=Node-6&version=7.4.5&externalPlugins=)), however, `babel-eslint` is failing on the same code.

I am adding just a failing test since I don't know how to fix it properly. Thank you very much for checking it... :)