### PR TITLE
Breaking: make AST match Espree 6

### DIFF
--- a/lib/babylon-to-espree/convertAST.js
+++ b/lib/babylon-to-espree/convertAST.js
@@ -47,26 +47,6 @@ const astTransformVisitor = {
   exit(path) {
     const node = path.node;
 
-    if (path.isJSXText()) {
-      node.type = "Literal";
-    }
-
-    if (
-      path.isRestElement() &&
-      path.parent &&
-      path.parent.type === "ObjectPattern"
-    ) {
-      node.type = "ExperimentalRestProperty";
-    }
-
-    if (
-      path.isSpreadElement() &&
-      path.parent &&
-      path.parent.type === "ObjectExpression"
-    ) {
-      node.type = "ExperimentalSpreadProperty";
-    }
-
     if (path.isTypeParameter()) {
       node.type = "Identifier";
       node.typeAnnotation = node.bound;

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "eslint-plugin-flowtype": "^3.11.1",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-prettier": "^3.1.0",
-    "espree": "^3.5.2",
+    "espree": "^6.0.0",
     "husky": "^1.0.0-rc.13",
     "lint-staged": "^7.2.2",
     "mocha": "^6.1.4",

--- a/test/specs/babel-eslint.js
+++ b/test/specs/babel-eslint.js
@@ -451,7 +451,9 @@ describe("babylon-to-espree", () => {
     });
 
     it("super outside method", () => {
-      parseAndAssertSame("function F() { super(); }");
+      assert.throws(() => {
+        parseAndAssertSame("function F() { super(); }");
+      }, /SyntaxError: 'super' keyword outside a method/);
     });
 
     it("StringLiteral", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -835,27 +835,10 @@
   dependencies:
     any-observable "^0.3.0"
 
-acorn-jsx@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
-  integrity sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=
-  dependencies:
-    acorn "^3.0.4"
-
 acorn-jsx@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.0.1.tgz#32a064fd925429216a09b141102bfdd185fae40e"
   integrity sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==
-
-acorn@^3.0.4:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
-  integrity sha1-ReN/s56No/JbruP/U2niu18iAXo=
-
-acorn@^5.5.0:
-  version "5.7.3"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
-  integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
 
 acorn@^6.0.7:
   version "6.2.0"
@@ -1529,14 +1512,6 @@ eslint@^6.0.1:
     strip-json-comments "^2.0.1"
     table "^5.2.3"
     text-table "^0.2.0"
-
-espree@^3.5.2:
-  version "3.5.4"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.4.tgz#b0f447187c8a8bed944b815a660bddf5deb5d1a7"
-  integrity sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==
-  dependencies:
-    acorn "^5.5.0"
-    acorn-jsx "^3.0.0"
 
 espree@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
This is a breaking change that change the baseline to espree 6.

Some node types has changes in accordance with changes in espree:
- `ExperimentalSpreadProperty` became `SpreadElement`.
- `ExperimentalRestProperty` became `RestElement`.
- `Literal` became `JSXText` (for JSXText).

fixes #759