### PR TITLE
fix: require eslint dependencies from eslint base (v10 backport)

### DIFF
--- a/lib/analyze-scope.js
+++ b/lib/analyze-scope.js
@@ -1,10 +1,14 @@
 "use strict";
 
 const t = require("@babel/types");
-const escope = require("eslint-scope");
-const Definition = require("eslint-scope/lib/definition").Definition;
-const OriginalPatternVisitor = require("eslint-scope/lib/pattern-visitor");
-const OriginalReferencer = require("eslint-scope/lib/referencer");
+const requireFromESLint = require("./require-from-eslint");
+
+const escope = requireFromESLint("eslint-scope");
+const Definition = requireFromESLint("eslint-scope/lib/definition").Definition;
+const OriginalPatternVisitor = requireFromESLint(
+  "eslint-scope/lib/pattern-visitor"
+);
+const OriginalReferencer = requireFromESLint("eslint-scope/lib/referencer");
 const fallback = require("eslint-visitor-keys").getKeys;
 const childVisitorKeys = require("./visitor-keys");
 

--- a/lib/require-from-eslint.js
+++ b/lib/require-from-eslint.js
@@ -1,0 +1,9 @@
+"use strict";
+
+const resolve = require("resolve");
+const eslintBase = require.resolve("eslint");
+
+module.exports = function requireFromESLint(id) {
+  const path = resolve.sync(id, { basedir: eslintBase });
+  return require(path);
+};

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "@babel/parser": "^7.0.0",
     "@babel/traverse": "^7.0.0",
     "@babel/types": "^7.0.0",
-    "eslint-scope": "3.7.1",
-    "eslint-visitor-keys": "^1.0.0"
+    "eslint-visitor-keys": "^1.0.0",
+    "resolve": "^1.12.0"
   },
   "scripts": {
     "test": "npm run lint && npm run test-only",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1754,6 +1754,11 @@ path-parse@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
 
+path-parse@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
+  integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+
 path-type@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
@@ -1893,6 +1898,13 @@ resolve-from@^1.0.0:
 resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
+
+resolve@^1.12.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
+  integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
+  dependencies:
+    path-parse "^1.0.6"
 
 resolve@^1.5.0:
   version "1.5.0"


### PR DESCRIPTION
Fixes #791 

This PR is inspired from the practice and discussion of #793. Thank you @nicolo-ribaudo for the idea and thank you everyone in the community from which I have learned a lot.