### PR TITLE
fix: require eslint dependencies from eslint base

### DIFF
--- a/lib/analyze-scope.js
+++ b/lib/analyze-scope.js
@@ -1,11 +1,15 @@
 "use strict";
 
-const t = require("@babel/core").types;
-const escope = require("eslint-scope");
-const Definition = require("eslint-scope/lib/definition").Definition;
-const OriginalPatternVisitor = require("eslint-scope/lib/pattern-visitor");
-const OriginalReferencer = require("eslint-scope/lib/referencer");
-const fallback = require("eslint-visitor-keys").getKeys;
+const t = require("@babel/types");
+const requireFromESLint = require("./require-from-eslint");
+
+const escope = requireFromESLint("eslint-scope");
+const Definition = requireFromESLint("eslint-scope/lib/definition").Definition;
+const OriginalPatternVisitor = requireFromESLint(
+  "eslint-scope/lib/pattern-visitor"
+);
+const OriginalReferencer = requireFromESLint("eslint-scope/lib/referencer");
+const fallback = requireFromESLint("eslint-visitor-keys").getKeys;
 const childVisitorKeys = require("./visitor-keys");
 
 const flowFlippedAliasKeys = t.FLIPPED_ALIAS_KEYS.Flow.concat([

--- a/lib/require-from-eslint.js
+++ b/lib/require-from-eslint.js
@@ -1,0 +1,9 @@
+"use strict";
+
+const resolve = require("resolve");
+const eslintBase = require.resolve("eslint");
+
+module.exports = function requireFromESLint(id) {
+  const path = resolve.sync(id, { basedir: eslintBase });
+  return require(path);
+};

--- a/lib/visitor-keys.js
+++ b/lib/visitor-keys.js
@@ -1,7 +1,8 @@
 "use strict";
 
 const BABEL_VISITOR_KEYS = require("@babel/core").types.VISITOR_KEYS;
-const ESLINT_VISITOR_KEYS = require("eslint-visitor-keys").KEYS;
+const requireFromESLint = require("./require-from-eslint");
+const ESLINT_VISITOR_KEYS = requireFromESLint("eslint-visitor-keys").KEYS;
 
 module.exports = Object.assign(
   {

--- a/package.json
+++ b/package.json
@@ -30,12 +30,11 @@
   ],
   "peerDependencies": {
     "@babel/core": ">=7.2.0",
-    "eslint": ">= 4.12.1"
+    "eslint": ">= 4.14.0"
   },
   "dependencies": {
-    "eslint-scope": "3.7.1",
-    "eslint-visitor-keys": "^1.0.0",
-    "semver": "^5.6.0"
+    "semver": "^5.6.0",
+    "resolve": "^1.12.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "peerDependencies": {
     "@babel/core": ">=7.2.0",
-    "eslint": ">= 4.14.0"
+    "eslint": ">=6.0.0"
   },
   "dependencies": {
     "semver": "^5.6.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eslint": ">=6.0.0"
   },
   "dependencies": {
-    "resolve": "^1.12.0"
+    "resolve": "^1.12.0",
     "semver": "^6.3.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3129,10 +3129,10 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.10.0, resolve@^1.11.0, resolve@^1.3.2, resolve@^1.5.0:
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.1.tgz#ea10d8110376982fef578df8fc30b9ac30a07a3e"
-  integrity sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==
+resolve@^1.10.0, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.3.2, resolve@^1.5.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
+  integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
   dependencies:
     path-parse "^1.0.6"
 


### PR DESCRIPTION
A revised version of #794 

Removed both `eslint-scope` and `eslint-visitor-keys` dependencies and bumped minimum ESLint requirement to `>=4.14.0`. Note that ESLint introduce `eslint-visitor-keys` dependency since 4.14.0