### PR TITLE
Add into 11.0.0 the fix from 10.0.2 to 10.0.3

### DIFF
--- a/lib/analyze-scope.js
+++ b/lib/analyze-scope.js
@@ -1,10 +1,15 @@
 "use strict";
 
 const t = require("@babel/core").types;
-const escope = require("eslint-scope");
-const Definition = require("eslint-scope/lib/definition").Definition;
-const OriginalPatternVisitor = require("eslint-scope/lib/pattern-visitor");
-const OriginalReferencer = require("eslint-scope/lib/referencer");
+
+const requireFromESLint = require("./require-from-eslint");
+
+const escope = requireFromESLint("eslint-scope");
+const Definition = requireFromESLint("eslint-scope/lib/definition").Definition;
+const OriginalPatternVisitor = requireFromESLint(
+  "eslint-scope/lib/pattern-visitor"
+);
+const OriginalReferencer = requireFromESLint("eslint-scope/lib/referencer");
 const fallback = require("eslint-visitor-keys").getKeys;
 const childVisitorKeys = require("./visitor-keys");
 

--- a/lib/require-from-eslint.js
+++ b/lib/require-from-eslint.js
@@ -1,0 +1,9 @@
+"use strict";
+
+const resolve = require("resolve");
+const eslintBase = require.resolve("eslint");
+
+module.exports = function requireFromESLint(id) {
+  const path = resolve.sync(id, { basedir: eslintBase });
+  return require(path);
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-eslint",
-  "version": "11.0.0-beta.0",
+  "version": "11.0.0-beta.1",
   "description": "Custom parser for ESLint",
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "license": "MIT",
@@ -33,8 +33,8 @@
     "eslint": ">= 4.12.1"
   },
   "dependencies": {
-    "eslint-scope": "3.7.1",
     "eslint-visitor-keys": "^1.0.0",
+    "resolve": "^1.12.0",
     "semver": "^5.6.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3136,6 +3136,13 @@ resolve@^1.10.0, resolve@^1.11.0, resolve@^1.3.2, resolve@^1.5.0:
   dependencies:
     path-parse "^1.0.6"
 
+resolve@^1.12.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
+  integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
+  dependencies:
+    path-parse "^1.0.6"
+
 restore-cursor@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"


### PR DESCRIPTION
**This PR just patches 11.0.0-beta.0 and versions it to 11.0.0-beta.1, in the exact same way 10.0.2 was patched and became 10.0.3**

*Problem*:
- _babel-eslint@10.0.3_ is being super weird for me (both _eslint 5 & 6_), in some Flow "edge cases",  by reporting **no-undef**. But miraculously, _babel-eslint@11.0.0-beta.0_ fixes that problem. 
- Unfortunately, _babel-eslint@11.0.0-beta.0_ exhibits (for _eslint < 6.2.0_) the exact same issue as _babel-eslint@10.0.2_ did, which was fixed here:  [fix from 10.0.2 => 10.0.3](https://github.com/babel/babel-eslint/commit/354953da5347a005fe566cc7dd338974aab50908)

*Solution*:
- Looking in the code for _babel-eslint@11.0.0-beta.0_, one can see [this code is missing](https://github.com/babel/babel-eslint/commit/354953da5347a005fe566cc7dd338974aab50908).
 
- All I did in this PR was **copy-paste**, **yarn**, and **version it to 11.0.0-beta.1**

PS: This is my first PR