### PR TITLE
add plugin classPrivateMethods

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -48,6 +48,7 @@ module.exports = function(code, options) {
       ["pipelineOperator", { proposal: "minimal" }],
       "nullishCoalescingOperator",
       "logicalAssignment",
+      "classPrivateMethods",
     ],
   };
 


### PR DESCRIPTION
This commit resolves error "Parsing error: This experimental syntax requires enabling the parser plugin: 'classPrivateMethods' "