### PR TITLE
chore: bump to eslint-scope 5 and eslint 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-eslint",
-  "version": "11.0.0-beta.0",
+  "version": "11.0.0-beta.1",
   "description": "Custom parser for ESLint",
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "license": "MIT",
@@ -22,7 +22,7 @@
     "changelog": "git log `git describe --tags --abbrev=0`..HEAD --pretty=format:' * %s (%an)' | grep -v 'Merge pull request'"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "main": "lib/index.js",
   "files": [
@@ -30,11 +30,11 @@
   ],
   "peerDependencies": {
     "@babel/core": ">=7.2.0",
-    "eslint": ">= 4.12.1"
+    "eslint": ">= 6.0.0"
   },
   "dependencies": {
-    "eslint-scope": "3.7.1",
-    "eslint-visitor-keys": "^1.0.0",
+    "eslint-scope": "5.0.0",
+    "eslint-visitor-keys": "^1.1.0",
     "semver": "^6.3.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1451,6 +1451,14 @@ eslint-scope@3.7.1:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-scope@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.0.0.tgz#e87c8887c73e8d1ec84f1ca591645c358bfc8fb9"
+  integrity sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
 eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
@@ -1466,7 +1474,7 @@ eslint-utils@^1.3.1:
   dependencies:
     eslint-visitor-keys "^1.0.0"
 
-eslint-visitor-keys@^1.0.0:
+eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
   integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==


### PR DESCRIPTION
This PR is meant to be a hot fix when we are in the transition from `babel-eslint` to `@babel/eslint-parser`. Dependencies are bumped to their latest versions so that it can work with `no-unused-rules` in eslint 6.

Closes #795 , closes #800 