### PR TITLE
Support custom parserOpts for babel parser

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,6 +24,9 @@ exports.parseForESLint = function(code, options = {}) {
   }
 
   options.babelOptions = options.babelOptions || {};
+  options.babelOptions.parserOpts = options.babelOptions.parserOpts || {};
+  options.babelOptions.parserOpts.plugins =
+    options.babelOptions.parserOpts.plugins || [];
   options.ecmaVersion = options.ecmaVersion || 2018;
   options.sourceType = options.sourceType || "module";
   options.allowImportExportEverywhere =

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -9,6 +9,7 @@ const {
 } = require("@babel/core");
 
 module.exports = function(code, options) {
+  const babelParserOpts = options.babelOptions.parserOpts;
   let opts = {
     sourceType: options.sourceType,
     filename: options.filePath,
@@ -28,12 +29,18 @@ module.exports = function(code, options) {
     ignore: options.babelOptions.ignore,
     only: options.babelOptions.only,
     parserOpts: {
+      ...babelParserOpts,
       allowImportExportEverywhere: options.allowImportExportEverywhere, // consistent with espree
       allowReturnOutsideFunction: true,
-      allowSuperOutsideMethod: true,
-      ranges: true,
-      tokens: true,
-      plugins: ["estree"],
+      allowSuperOutsideMethod:
+        babelParserOpts.allowSuperOutsideMethod === undefined
+          ? true
+          : babelParserOpts.allowSuperOutsideMethod,
+      ranges:
+        babelParserOpts.ranges === undefined ? true : babelParserOpts.ranges,
+      tokens:
+        babelParserOpts.tokens === undefined ? true : babelParserOpts.tokens,
+      plugins: ["estree", ...babelParserOpts.plugins],
     },
     caller: {
       name: "babel-eslint",


### PR DESCRIPTION
Not sure if I should PR this here or to the monorepo?

This supports custom `parserOpts` being passed in to the babel parser through the eslint config.